### PR TITLE
docs: adiciona README raiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# PTCG Premium MVP v2
+
+Repositório com as partes principais do projeto **PTCG Premium**, incluindo a API e a aplicação web.
+
+## Estrutura do repositório
+
+- **backend/** &mdash; Endpoints da API. Veja [backend/README.md](backend/README.md).
+- **frontend/** &mdash; Aplicativo web em React. Veja [frontend/README.md](frontend/README.md).
+- **docs/** &mdash; Documentação complementar.
+
+## Desenvolvimento
+
+Requisitos: Node.js 18+
+
+### Backend
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Para detalhes adicionais, consulte a pasta [docs/](docs/).


### PR DESCRIPTION
## Summary
- add root README with project goals, structure, and dev instructions

## Testing
- `cd backend && npm test` (missing script)
- `cd frontend && npm install` (403 Forbidden)
- `cd frontend && npm test` (vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4b67f4ca0832194eb7843166b9a51