### PR TITLE
docs: expand backend architecture overview

### DIFF
--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -1,5 +1,37 @@
-# Backend docs for Import Logs (updated)
+# Backend Architecture Overview
 
-## Wave 3 Opponents (2025-09-08T00:03:18)
-- Strict CORS + preflight; NDJSON logs; /api/home; /api/import-logs/parse & /commit (deckName obrigatório);
-- /api/live/opponents-agg & /logs;
+## Directory Overview
+- **events/** – endpoints that keep a per-session list of ad-hoc events in memory.
+- **live/** – PTCG Live API handlers and aggregations backed by Firestore.
+- **importing/** – parses client log files and commits them through `/import-logs`.
+- **logs/** – exposes recent request logs stored in the session.
+- **middleware/** – shared Express middleware such as Firebase authentication.
+
+## CORS, CSRF and NDJSON Logs
+
+### CORS
+The server uses the [`cors`](https://github.com/expressjs/cors) package with a single allowed origin taken from `CORS_ORIGIN`.
+Credentials are enabled and a preflight handler is registered. Only `Content-Type`,
+`Authorization` and `X-CSRF-Token` headers are accepted.
+
+### CSRF
+A double-submit token is issued in a `csrfToken` cookie (`SameSite=Strict`,
+`HttpOnly` and `Secure` in production). For non-idempotent requests the client must
+send the same value in the `X-CSRF-Token` header or the request is rejected with `403`.
+See [docs/CSRF.md](../../docs/CSRF.md) for the full flow.
+
+### NDJSON log rotation
+Each request and JSON response is appended to `logs/requests.ndjson` and
+`logs/responses.ndjson`. Once a file reaches **5&nbsp;MB** it is renamed with a
+timestamp and a new file is opened, providing simple size-based log rotation.
+
+## Request Flow and External Dependencies
+
+```mermaid
+flowchart TD
+    Client -->|HTTP| Server
+    Server -->|CORS & CSRF middleware| Routes
+    Routes -->|Firestore SDK| Firestore[(Firestore)]
+    Routes -->|Firebase Admin| Auth[(Firebase Auth)]
+    Server -->|NDJSON log streams| LogFiles[(NDJSON Logs)]
+```


### PR DESCRIPTION
## Summary
- document backend directory purposes
- outline CORS, CSRF and NDJSON log rotation
- add request flow diagram with Firestore and Firebase Auth

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4b970d7008321b9df6649bbcf145a