### PR TITLE
docs: document frontend API configuration and CSRF headers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,6 +5,15 @@ Vite + React + Tailwind (ESM).
 ## Requisitos
 - Node.js 18+
 
+## Configuração
+Crie um arquivo `.env` na pasta `frontend` com as variáveis:
+
+```sh
+VITE_API_BASE_URL=http://localhost:8787
+```
+
+Veja o [Guia de Integração](docs/INTEGRATION_GUIDE.md) para detalhes sobre cookies, CSRF e cabeçalhos.
+
 ## Instalação
 ```bash
 npm install
@@ -20,7 +29,6 @@ npm run dev
 npm run build
 npm run preview
 ```
-
 
 ## New route
 Use `#/tcg-fisico/eventos/<id>` or `#/eventos/<id>` to open the Event Physical Summary Page. If you navigate programmatically, you can pass `history.pushState({eventFromProps: evento}, '', '#/tcg-fisico/eventos/'+evento.id)`.

--- a/frontend/docs/INTEGRATION_GUIDE.md
+++ b/frontend/docs/INTEGRATION_GUIDE.md
@@ -3,3 +3,41 @@
 - Página: `src/pages/TCGLiveDatePage.jsx`
 - Rota: `#/tcg-live/datas/:date`
 - Widget "Todos os Registros": linkar as datas para essa rota.
+
+## Configurar `VITE_API_BASE_URL`
+
+1. Crie um arquivo `.env` na pasta `frontend` (ou ajuste o existente).
+2. Defina a URL da API usada pelas chamadas do `fetch`:
+   ```sh
+   VITE_API_BASE_URL=http://localhost:8787
+   ```
+3. Reinicie o servidor do Vite para que a variável seja carregada.
+
+## Enviar `X-CSRF-Token` com cookies
+
+1. Faça uma requisição segura (ex.: `GET /api/health`) para receber o cookie `csrfToken`.
+2. Leia o valor desse cookie no cliente.
+3. Em requisições que alteram dados (`POST`, `PATCH`, `DELETE` etc.), envie o valor no cabeçalho `X-CSRF-Token`.
+4. Use sempre `credentials: 'include'` para que o cookie acompanhe a requisição.
+
+## Exemplo de `fetch`
+
+```js
+const csrf = document.cookie
+  .split('; ')
+  .find(r => r.startsWith('csrfToken='))
+  ?.split('=')[1];
+
+const idToken = await getIdToken(); // do Firebase
+
+await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/live/events`, {
+  method: 'POST',
+  credentials: 'include',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${idToken}`,
+    'X-CSRF-Token': csrf,
+  },
+  body: JSON.stringify({ /* ...payload... */ })
+});
+```


### PR DESCRIPTION
## Summary
- explain how to set `VITE_API_BASE_URL`, send `X-CSRF-Token`, and include credentials
- add frontend README configuration section linking to integration guide

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c4bbf148208321a5e39df5f1e83f97