### PR TITLE
Allow CSRF token to be readable in browser

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -95,7 +95,7 @@ app.use((req, res, next) => {
     token = nanoid();
     res.cookie(CSRF_COOKIE, token, {
       sameSite: "strict",
-      httpOnly: true,
+      httpOnly: false,
       secure: process.env.NODE_ENV === "production"
     });
   }


### PR DESCRIPTION
## Summary
- disable `httpOnly` on CSRF cookie so token can be accessed by browser scripts

## Testing
- `npm test` (fails: Missing script "test")
- `node backend/src/server.js` (manually started and stopped)


------
https://chatgpt.com/codex/tasks/task_e_68c4c11668848321a7a4382c0adb8217