### PR TITLE
Ensure CSRF token is fetched when absent

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,7 +7,11 @@ function getCsrfToken(){
 
 export async function api(path, opts = {}) {
   const headers = { 'Content-Type': 'application/json', ...(opts.headers||{}) };
-  const token = getCsrfToken();
+  let token = getCsrfToken();
+  if (!token) {
+    await fetch(`${API_BASE}/api/health`, { credentials:'include' });
+    token = getCsrfToken();
+  }
   if (token) headers['X-CSRF-Token'] = token;
   const res = await fetch(`${API_BASE}${path}`, {
     credentials: 'include',


### PR DESCRIPTION
## Summary
- Retrieve CSRF token via health endpoint when not present
- Add token to request headers after ensuring cookie is set

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c4c20e99d08321b71c83a3bf320f54