### PR TITLE
feat: sort opponents in memory

### DIFF
--- a/backend/src/live/routes.js
+++ b/backend/src/live/routes.js
@@ -353,7 +353,6 @@ r.get("/opponents-agg", async (req, res) => {
   try {
     const snap = await db
       .collection("liveOpponentsAgg")
-      .orderBy("opponentName")
       .limit(500)
       .get();
     const out = [];
@@ -373,7 +372,7 @@ r.get("/opponents-agg", async (req, res) => {
           topDeck = { deckKey: d.topDeckKey };
         }
       }
-      out.push({ opponentName: d.opponentName, counts: d.counts, wr: d.wr, topDeck });
+      out.push({ opponentName: d.opponentName || doc.id, counts: d.counts, wr: d.wr, topDeck });
     }
     res.json(out.sort((a,b)=> (a.opponentName||'').localeCompare(b.opponentName||'')));
   } catch (e){


### PR DESCRIPTION
## Summary
- remove Firestore `orderBy` from `/opponents-agg` and sort results in memory
- fall back to Firestore document ID when opponent name is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run src/live/routes.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `FIRESTORE_EMULATOR_HOST=localhost:8080 npm start` then `curl -i http://localhost:8787/api/live/opponents-agg` *(fails: opponents_agg_failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fe6b34dc8321936e45cf269fbe2e