### PR TITLE
feat: improve top deck display

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -149,15 +149,26 @@ const TopOpponentsWidget = ({ home }) => {
       {rows.map((r, i) => {
         const counts = r.counts || { W: 0, L: 0, T: 0 };
         const wr = typeof r.wr === "number" ? r.wr : 0;
-        const topDeckKey = r?.topDeck?.deckKey || "";
-        const topDeckPokemons = Array.isArray(r?.topDeck?.pokemons) ? r.topDeck.pokemons : undefined;
+        const topDeckName =
+          r.topDeckKey ||
+          r.topDeck?.deckKey ||
+          r.topDeckName ||
+          r.topDeck?.name ||
+          r.deckName ||
+          "";
+        const topDeckLabel = prettyDeckKey(topDeckName || "") || "—";
+        const topDeckPokemons = Array.isArray(r.topPokemons)
+          ? r.topPokemons
+          : Array.isArray(r.topDeck?.pokemons)
+            ? r.topDeck.pokemons
+            : undefined;
         return (
           <div key={i} className="grid grid-cols-12 items-center gap-2 py-2 border-b border-zinc-800/60 last:border-b-0">
             <div className="col-span-3 truncate">{r.opponentName}</div>
             <div className="col-span-3 text-center"><Pill>{wr}%</Pill></div>
             <div className="col-span-2 text-center"><WLTriplet {...counts} /></div>
             <div className="col-span-4 flex items-center justify-center">
-              <DeckLabel deckName={prettyDeckKey(topDeckKey) || "—"} pokemonHints={topDeckPokemons} />
+              <DeckLabel deckName={topDeckLabel} pokemonHints={topDeckPokemons} />
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- enhance opponent top deck display with multiple name fallbacks and label
- use topPokemons as fallback for deck pokemon hints

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c60b346c608321a8d86e1e003b1422