### PR TITLE
Show opponent deck when top deck missing

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -154,9 +154,10 @@ const TopOpponentsWidget = ({ home }) => {
           r.topDeck?.deckKey ||
           r.topDeckName ||
           r.topDeck?.name ||
+          r.opponentDeck ||
           r.deckName ||
           "";
-        const topDeckLabel = prettyDeckKey(topDeckName || "") || "—";
+        const topDeckLabel = prettyDeckKey(topDeckName) || topDeckName || "—";
         const topDeckPokemons = Array.isArray(r.topPokemons)
           ? r.topPokemons
           : Array.isArray(r.topDeck?.pokemons)


### PR DESCRIPTION
## Summary
- Display opponentDeck in HomePage's TopOpponentsWidget when the opponent has no recorded top deck
- Use opponent deck name in deck label fallback

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c60e883a688321ba5ae4f573b44f27