### PR TITLE
Add deck modal and display for physical events

### DIFF
--- a/frontend/src/EventPhysicalSummaryPage.jsx
+++ b/frontend/src/EventPhysicalSummaryPage.jsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState, useEffect } from "react";
 import BackButton from "./components/BackButton";
 import PokemonAutocomplete from "./components/PokemonAutocomplete";
+import DeckLabel from "./components/DeckLabel.jsx";
+import DeckModal from "./components/DeckModal.jsx";
 import { getEvent } from "./eventsRepo.js";
 import { getPokemonIcon, FALLBACK } from "./services/pokemonIcons.js";
 
@@ -212,8 +214,11 @@ export default function EventPhysicalSummaryPage({ eventFromProps }) {
     date: "2025-08-20",
     type: "Locals",
     format: "SVI-WHT/BLK",
-    deckMonA: "Dragapult",
-    deckMonB: "",
+    deck: {
+      deckName: "",
+      pokemon1: "",
+      pokemon2: "",
+    },
   };
 
   // IMPORTANTE: manter dados no estado para edição sem mutar const
@@ -236,6 +241,7 @@ export default function EventPhysicalSummaryPage({ eventFromProps }) {
 
   const [rounds, setRounds] = useState([]);
   const [editRoundIndex, setEditRoundIndex] = useState(null);
+  const [editingDeck, setEditingDeck] = useState(false);
 
   const isEditing = editRoundIndex !== null;
   const editingNumber = isEditing ? (rounds[editRoundIndex]?.number ?? (editRoundIndex + 1)) : null;
@@ -490,6 +496,23 @@ function validateAndSave() {
               {eventData.classification && eventData.classification !== "—" ? (
                 <div className="text-lg font-bold text-right mt-8">{eventData.classification}</div>
               ) : null}
+              {eventData.deck?.deckName && (
+                <div className="mt-2 flex justify-end">
+                  <DeckLabel
+                    deckName={eventData.deck.deckName}
+                    pokemonHints={[eventData.deck.pokemon1, eventData.deck.pokemon2]}
+                  />
+                </div>
+              )}
+              <div className="mt-2 flex justify-end">
+                <button
+                  type="button"
+                  className="px-2 py-1 text-xs rounded-md border border-zinc-700 text-zinc-200 hover:bg-zinc-800"
+                  onClick={() => setEditingDeck(true)}
+                >
+                  Deck
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -772,6 +795,17 @@ function validateAndSave() {
           </div>
         )}
       </div>
+
+      {editingDeck && (
+        <DeckModal
+          initialDeck={eventData.deck}
+          onCancel={() => setEditingDeck(false)}
+          onSave={(deck) => {
+            setEventData((prev) => ({ ...prev, deck }));
+            setEditingDeck(false);
+          }}
+        />
+      )}
 
       {/* Modal de edição do evento */}
       {editingEvent && (

--- a/frontend/src/components/DeckModal.jsx
+++ b/frontend/src/components/DeckModal.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import PokemonAutocomplete from "./PokemonAutocomplete.jsx";
+
+export default function DeckModal({ initialDeck, onCancel, onSave }) {
+  const [deckName, setDeckName] = useState(initialDeck?.deckName || "");
+  const [pokemon1, setPokemon1] = useState(
+    initialDeck?.pokemon1
+      ? { name: initialDeck.pokemon1, slug: initialDeck.pokemon1 }
+      : null
+  );
+  const [pokemon2, setPokemon2] = useState(
+    initialDeck?.pokemon2
+      ? { name: initialDeck.pokemon2, slug: initialDeck.pokemon2 }
+      : null
+  );
+
+  const handleSave = () => {
+    onSave &&
+      onSave({
+        deckName: deckName.trim(),
+        pokemon1: pokemon1?.slug || "",
+        pokemon2: pokemon2?.slug || "",
+      });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5 w-[min(480px,90vw)]">
+        <h3 className="text-lg font-bold mb-3">Deck</h3>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm text-zinc-400">Nome do Deck</label>
+            <input
+              className="w-full bg-zinc-900/60 border border-zinc-800 rounded-xl px-3 py-2 text-zinc-100"
+              value={deckName}
+              onChange={(e) => setDeckName(e.target.value)}
+            />
+          </div>
+          <PokemonAutocomplete
+            label="Pokémon 1"
+            required
+            value={pokemon1}
+            onChange={setPokemon1}
+          />
+          <PokemonAutocomplete
+            label="Pokémon 2"
+            value={pokemon2}
+            onChange={setPokemon2}
+          />
+        </div>
+        <div className="mt-4 flex gap-3 justify-end">
+          <button
+            className="px-4 py-2 rounded-xl border border-zinc-700 text-zinc-200"
+            onClick={onCancel}
+          >
+            Cancelar
+          </button>
+          <button
+            className="px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold"
+            onClick={handleSave}
+          >
+            Salvar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow editing event deck with new DeckModal
- show deck button and deck label with icons on event summary

## Testing
- `npm test` *(fails: Failed to load url node-fetch / express)*
- `npm run lint` *(fails: no-undef and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c70afa41288321917984d5d4d3dbd5