### PR TITLE
feat: integrate physical events API

### DIFF
--- a/frontend/src/eventsRepo.js
+++ b/frontend/src/eventsRepo.js
@@ -1,6 +1,7 @@
 import { api } from "./services/api.js";
+import { getPhysicalEvent, postPhysicalEvent } from "./services/physicalApi.js";
 
-const API_BASE = '/api/events';
+const API_BASE = '/api/physical/events';
 
 let migrationDone = false;
 async function migrateLegacy() {
@@ -34,7 +35,7 @@ export async function getAllEvents() {
 
 export async function getEvent(id) {
   try {
-    return await api(`${API_BASE}/${encodeURIComponent(id)}`);
+    return await getPhysicalEvent(id);
   } catch (err) {
     console.warn('Falha ao obter evento', err);
     return null;
@@ -43,7 +44,7 @@ export async function getEvent(id) {
 
 export async function createEvent(ev) {
   try {
-    return await api(API_BASE, { method: 'POST', body: JSON.stringify(ev) });
+    return await postPhysicalEvent(ev);
   } catch (err) {
     console.warn('Falha ao salvar evento', err);
     throw err;

--- a/frontend/src/services/physicalApi.js
+++ b/frontend/src/services/physicalApi.js
@@ -1,0 +1,13 @@
+import { api } from "./api.js";
+
+export const postPhysicalEvent = (payload) =>
+  api(`/api/physical/events`, { method: 'POST', body: JSON.stringify(payload) });
+
+export const getPhysicalEvent = (id) =>
+  api(`/api/physical/events/${encodeURIComponent(id)}`);
+
+export const postPhysicalRound = (eventId, payload) =>
+  api(`/api/physical/events/${encodeURIComponent(eventId)}/rounds`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });


### PR DESCRIPTION
## Summary
- add physical events API service with helpers for events and rounds
- point events repository to /api/physical/events
- persist rounds via API in EventPhysicalSummaryPage

## Testing
- `npm test -- --run` *(fails: Failed to load url express)*
- `npm run lint` *(fails: 'setInterval' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c70d7545a4832188451adddff2fc19