### PR TITLE
docs: document physical routes and pokedex

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# PTCG Backend — TCG Live endpoints
+# PTCG Backend — TCG Live e Físico
 
 ## Rodar em dev (com Firestore Emulator)
 
@@ -91,6 +91,45 @@ fetch('/api/live/events', {
 - `GET    /api/live/tournaments/:id`
 
 Agregações (dias, decks, oponentes, torneios) são atualizadas **on write** pelo servidor.
+
+### Endpoints `/api/physical/*`
+
+Principais rotas para eventos do TCG Físico (espelham as de Live):
+
+- `POST   /api/physical/events`
+- `GET    /api/physical/events/:id`
+- `PATCH  /api/physical/events/:id`
+- `DELETE /api/physical/events/:id`
+- `GET    /api/physical/summary?limitDays=5`
+- `GET    /api/physical/days/:date`
+- `GET    /api/physical/decks`
+
+Exemplo de criação de evento:
+
+```http
+POST /api/physical/events
+Content-Type: application/json
+
+{
+  "you": "Ash",
+  "opponent": "Gary",
+  "deckName": "Chien-Pao/Baxcalibur",
+  "opponentDeck": "Miraidon",
+  "result": "W",
+  "round": 1,
+  "pokemons": ["chien-pao-ex", "baxcalibur"]
+}
+```
+
+Resposta: `201 { "eventId": "abc123" }`.
+
+### Pokédex e persistência de Pokémon
+
+As rotas `/api/pokedex/search` e `/api/pokedex/by-slug/:slug` consultam a PokéAPI e
+armazenam os resultados em cache no Firestore.
+
+Eventos físicos aceitam um campo `pokemons` com até dois slugs. Esses valores são
+persistidos junto ao evento e reaproveitados para avatares e agregações.
 
 ## Sessão em memória
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,32 @@
+# Arquitetura Geral
+
+O projeto expõe dois conjuntos de rotas na API Express:
+
+- **/api/live/** – registra e agrega partidas do TCG Live.
+- **/api/physical/** – registra eventos do TCG Físico.
+
+Cada grupo mantém suas próprias coleções no Firestore e processa agregações
+independentemente.
+
+## Camada de serviços
+
+Funções compartilhadas residem em `src/services/` e são usadas por ambas as
+rotas. Elas isolam integrações externas e reutilizam lógica:
+
+- `pokedex.js` – consulta a PokéAPI e armazena resultados em cache no Firestore.
+- `deckHints.js` – sugere Pokémon para nomes de decks.
+
+As rotas chamam essas funções em vez de acessar APIs externas diretamente.
+
+## Fluxo de requisição
+
+```mermaid
+flowchart TD
+    Client -->|HTTP| Express
+    Express -->|rotas /api/live| Live
+    Express -->|rotas /api/physical| Physical
+    Live --> Services
+    Physical --> Services
+    Services -->|Firestore SDK| Firestore[(Firestore)]
+    Services -->|PokéAPI| PokeAPI[(PokéAPI)]
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,5 +30,40 @@ npm run build
 npm run preview
 ```
 
-## New route
-Use `#/tcg-fisico/eventos/<id>` or `#/eventos/<id>` to open the Event Physical Summary Page. If you navigate programmatically, you can pass `history.pushState({eventFromProps: evento}, '', '#/tcg-fisico/eventos/'+evento.id)`.
+## Rotas `/tcg-fisico/*`
+As telas do TCG Físico vivem sob `#/tcg-fisico`:
+
+- `#/tcg-fisico` – visão geral
+- `#/tcg-fisico/eventos/:id` – resumo e rounds de um evento
+
+Navegação programática para a página de evento:
+
+```js
+history.pushState({ eventFromProps: evento }, '', `#/tcg-fisico/eventos/${evento.id}`);
+```
+
+Essas telas consomem os endpoints do backend em `/api/physical/*`. Exemplo de criação de evento:
+
+```http
+POST /api/physical/events
+Content-Type: application/json
+
+{
+  "you": "Ash",
+  "opponent": "Gary",
+  "deckName": "Chien-Pao/Baxcalibur",
+  "opponentDeck": "Miraidon",
+  "result": "W",
+  "round": 1,
+  "pokemons": ["chien-pao-ex", "baxcalibur"]
+}
+```
+
+Resposta: `201 { "eventId": "abc123" }`.
+
+## Deck modal e PokéAPI
+O componente `DeckModal` permite informar o nome do deck e até dois Pokémon. Ele usa `PokemonAutocomplete`, que consulta
+`/api/pokedex/search` no backend (proxy para a PokéAPI com cache).
+
+Os slugs dos Pokémon escolhidos são enviados junto com o evento (`pokemons: ["chien-pao-ex", "baxcalibur"]`) e o backend os
+persiste para reaproveitar avatares e agregações.


### PR DESCRIPTION
## Summary
- describe `/tcg-fisico/*` frontend routes and example `/api/physical/events` payload
- document backend `/api/physical/*` endpoints and Pokédex caching of Pokémon
- add architecture doc outlining Live vs Physical separation and shared service layer

## Testing
- `npm test` (frontend) *(fails: Failed to load url node-fetch / express)*
- `npm test` (backend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c70f276f0c83219b98373c75ad9a46