### PR TITLE
Use history state when navigating to event summary

### DIFF
--- a/frontend/src/components/NovoRegistroDialog.jsx
+++ b/frontend/src/components/NovoRegistroDialog.jsx
@@ -159,7 +159,12 @@ const NovoRegistroDialog = forwardRef(function NovoRegistroDialog(
       if (typeof onCreated === "function")
         onCreated({ ...payload, eventId });
 
-      if (eventId) location.hash = `#/eventos/${eventId}`;
+      if (eventId)
+        history.pushState(
+          { eventFromProps: { ...payload, id: eventId } },
+          "",
+          "#/tcg-fisico/eventos/" + eventId,
+        );
 
       setOpen(false);
     } catch (err) {


### PR DESCRIPTION
## Summary
- navigate to new event using history.pushState and include initial event data

## Testing
- `npm test` *(fails: Failed to load url node-fetch and express)*
- `npm run lint` *(fails: many lint errors e.g., console is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c8648e8832193f15cf2c68ac1ce