### PR TITLE
Dispatch hash change after creating event

### DIFF
--- a/frontend/src/components/NovoRegistroDialog.jsx
+++ b/frontend/src/components/NovoRegistroDialog.jsx
@@ -159,12 +159,14 @@ const NovoRegistroDialog = forwardRef(function NovoRegistroDialog(
       if (typeof onCreated === "function")
         onCreated({ ...payload, eventId });
 
-      if (eventId)
+      if (eventId) {
         history.pushState(
           { eventFromProps: { ...payload, id: eventId } },
           "",
           "#/tcg-fisico/eventos/" + eventId,
         );
+        window.dispatchEvent(new HashChangeEvent("hashchange"));
+      }
 
       setOpen(false);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Trigger hashchange after pushing new event route so navigation updates

## Testing
- `npm test` *(fails: Failed to load url node-fetch (resolved id: node-fetch) in /workspace/Projeto-PTCG-Premium-mvp-v2/frontend/src/live/load.test.js. Does the file exist?)*
- `npm run lint` *(fails: 75 errors including 'console is not defined' in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7630705808321a956386214254bf9