### PR TITLE
Add API route for physical event rounds

### DIFF
--- a/backend/src/physical/routes.js
+++ b/backend/src/physical/routes.js
@@ -156,6 +156,24 @@ async function recomputeRoundsAgg(eventId) {
   }, { merge: true });
 }
 
+r.get("/events/:eventId/rounds", async (req, res) => {
+  try {
+    const eventId = String(req.params.eventId || "");
+    if (!eventId) return res.status(400).json({ error: "invalid_event" });
+    const snap = await db
+      .collection("physicalEvents")
+      .doc(eventId)
+      .collection("rounds")
+      .orderBy("number")
+      .get();
+    const rounds = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+    return res.json(rounds);
+  } catch (e) {
+    console.error("[GET /physical/events/:eventId/rounds]", e);
+    return res.status(500).json({ error: "rounds_list_failed" });
+  }
+});
+
 r.post("/events/:eventId/rounds", authMiddleware, async (req, res) => {
   try {
     const eventId = String(req.params.eventId || "");

--- a/frontend/src/EventPhysicalSummaryPage.jsx
+++ b/frontend/src/EventPhysicalSummaryPage.jsx
@@ -5,7 +5,7 @@ import PokemonAutocomplete from "./components/PokemonAutocomplete";
 import DeckLabel from "./components/DeckLabel.jsx";
 import DeckModal from "./components/DeckModal.jsx";
 import { getEvent } from "./eventsRepo.js";
-import { postPhysicalRound } from "./services/physicalApi.js";
+import { postPhysicalRound, getPhysicalRounds } from "./services/physicalApi.js";
 import { getPokemonIcon, FALLBACK } from "./services/pokemonIcons.js";
 
 // helper: get store slug from hash query
@@ -244,6 +244,10 @@ export default function EventPhysicalSummaryPage({ eventFromProps }) {
   }, [eventId]);
 
   const [rounds, setRounds] = useState([]);
+  useEffect(() => {
+    if (!eventId) return;
+    getPhysicalRounds(eventId).then((rs) => setRounds(rs || []));
+  }, [eventId]);
   const [editRoundIndex, setEditRoundIndex] = useState(null);
   const [editingDeck, setEditingDeck] = useState(false);
 

--- a/frontend/src/services/physicalApi.js
+++ b/frontend/src/services/physicalApi.js
@@ -6,6 +6,9 @@ export const postPhysicalEvent = (payload) =>
 export const getPhysicalEvent = (id) =>
   api(`/api/physical/events/${encodeURIComponent(id)}`);
 
+export const getPhysicalRounds = (eventId) =>
+  api(`/api/physical/events/${encodeURIComponent(eventId)}/rounds`);
+
 // POST /api/physical/events/:eventId/rounds
 // Returns the saved round object from the backend
 export const postPhysicalRound = async (eventId, payload) => {


### PR DESCRIPTION
## Summary
- add backend endpoint to list rounds for a physical event
- expose `getPhysicalRounds` service and load rounds on summary page

## Testing
- `npm test` *(backend: Missing script: "test")*
- `npm test` *(frontend: No test suite found in file /workspace/Projeto-PTCG-Premium-mvp-v2/frontend/src/live/load.test.js)*
- `npm run lint` *(frontend: 75 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c7656356608321be2a5f9b91c7a135