### PR TITLE
check event id before saving physical round

### DIFF
--- a/frontend/src/EventPhysicalSummaryPage.jsx
+++ b/frontend/src/EventPhysicalSummaryPage.jsx
@@ -377,8 +377,12 @@ const [expandedRoundId, setExpandedRoundId] = useState(null);
     });
     setEditRoundIndex(idx);
     try{ document.getElementById("round-form")?.scrollIntoView({behavior:"smooth"}); }catch{}
-  }
+  } 
   async function validateAndSave() {
+    if (!eventData?.id) {
+      showToast("ID do evento não encontrado", "error");
+      return;
+    }
   // Regra: Se ID selecionado, oponente é obrigatório; deck não é obrigatório
   if (form.id) {
     if (!form.opponentName || !form.opponentName.trim()) {
@@ -411,12 +415,6 @@ const [expandedRoundId, setExpandedRoundId] = useState(null);
       g3: canShowGame3() ? { ...form.g3 } : { result: "", order: "" },
       flags: { noShow: form.noShow, bye: form.bye, id: form.id },
     };
-
-    if (!eventData.id) {
-      showToast("ID do evento não encontrado. Não foi possível salvar o round.", "error");
-      return;
-    }
-
     try {
       const saved = await postPhysicalRound(eventData.id, round);
       const finalRound = {


### PR DESCRIPTION
## Summary
- avoid saving round if event id is missing and show toast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c76c6c044c8321a25e7c9d4c8173e3