### PR TITLE
Add metadata fields to physical event API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -111,6 +111,12 @@ POST /api/physical/events
 Content-Type: application/json
 
 {
+  "dia": "2024-05-01",
+  "nome": "League Challenge",
+  "tipo": "LC",
+  "local": "Loja XPTO",
+  "formato": "Standard",
+  "classificacao": "League Challenge",
   "you": "Ash",
   "opponent": "Gary",
   "deckName": "Chien-Pao/Baxcalibur",
@@ -122,6 +128,27 @@ Content-Type: application/json
 ```
 
 Resposta: `201 { "eventId": "abc123" }`.
+
+`GET /api/physical/events/:id` retorna:
+
+```json
+{
+  "eventId": "abc123",
+  "date": "2024-05-01",
+  "name": "League Challenge",
+  "type": "LC",
+  "storeOrCity": "Loja XPTO",
+  "format": "Standard",
+  "classification": "League Challenge",
+  "you": "Ash",
+  "opponent": "Gary",
+  "deckName": "Chien-Pao/Baxcalibur",
+  "opponentDeck": "Miraidon",
+  "result": "W",
+  "round": 1,
+  "pokemons": ["chien-pao-ex", "baxcalibur"]
+}
+```
 
 ### Pokédex e persistência de Pokémon
 

--- a/backend/src/physical/routes.js
+++ b/backend/src/physical/routes.js
@@ -25,7 +25,12 @@ r.post("/events", authMiddleware, async (req, res) => {
   const opponentDeckKey = normalizeDeckKey(opponentDeck);
 
   const createdAt = body.createdAt || now;
-  const date = dateKeyFromTs(createdAt);
+  const date = body.dia ? String(body.dia) : dateKeyFromTs(createdAt);
+  const name = body.nome ? String(body.nome) : null;
+  const type = body.tipo ? String(body.tipo) : null;
+  const storeOrCity = body.local ? String(body.local) : null;
+  const format = body.formato ? String(body.formato) : null;
+  const classification = body.classificacao ? String(body.classificacao) : null;
   const isOnlineTourney = !!body.isOnlineTourney;
   const limitlessId = body.limitlessId || null;
   const tourneyName = body.tourneyName || null;
@@ -42,7 +47,8 @@ r.post("/events", authMiddleware, async (req, res) => {
     you, opponent, deckName, opponentDeck,
     playerDeckKey, opponentDeckKey,
     isOnlineTourney, limitlessId, tourneyName, tournamentId,
-    result, round, placement, rawLog, lang, pokemons
+    result, round, placement, rawLog, lang, pokemons,
+    name, type, storeOrCity, format, classification
   };
   await db.collection("physicalEvents").doc(eventId).set(doc, { merge: true });
   await recomputeAllForEvent(doc);


### PR DESCRIPTION
## Summary
- capture physical event metadata (`dia`, `nome`, `tipo`, `local`, `formato`, `classificacao`) and persist in Firestore
- document new payload and response structure for physical events

## Testing
- `npm test --prefix backend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7766ee4388321a129f964e43ef07c