### PR TITLE
Prevent autocomplete search when selected value matches query

### DIFF
--- a/frontend/src/components/PokemonAutocomplete.jsx
+++ b/frontend/src/components/PokemonAutocomplete.jsx
@@ -15,6 +15,7 @@ export default function PokemonAutocomplete({ label, required=false, value, onCh
     let abort=false;
     const run = async () => {
       const s = q.trim();
+      if (value?.name && value.name === s){ setItems([]); setOpen(false); return; }
       if (s.length < min){ setItems([]); setOpen(false); return; }
       try{
         const res = await searchPokemon(s);
@@ -23,7 +24,7 @@ export default function PokemonAutocomplete({ label, required=false, value, onCh
     };
     run();
     return () => { abort = true; };
-  }, [q]);
+  }, [q, value?.name]);
 
   const handleBlur = () => {
     // espera clique no item (onMouseDown) antes de fechar


### PR DESCRIPTION
## Summary
- skip the Pokémon search when the current query matches the selected value to keep suggestions closed
- include the selected value in the search effect dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c87f1fb5bc83218436f04a6787fef3