### PR TITLE
Add delete flow for physical events

### DIFF
--- a/frontend/src/eventsRepo.js
+++ b/frontend/src/eventsRepo.js
@@ -60,6 +60,15 @@ export async function updateEvent(id, patch) {
   }
 }
 
+export async function deleteEvent(id) {
+  try {
+    return await api(`/api/physical/events/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  } catch (err) {
+    console.warn('Falha ao excluir evento', err);
+    throw err;
+  }
+}
+
 export function getMatchesCount(ev) {
   if (Array.isArray(ev?.rounds)) return ev.rounds.length;
   if (ev?.stats?.totalMatches != null) return Number(ev.stats.totalMatches) || 0;


### PR DESCRIPTION
## Summary
- add a deleteEvent helper to call the physical events DELETE endpoint
- wire the physical event summary trash button to confirm, delete, toast feedback, and redirect on success
- track deleting state to disable the button while a request is in flight

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c891db16808321a6eeb81fae10d0b6