### PR TITLE
Handle missing opponent pokemon data safely

### DIFF
--- a/frontend/src/EventPhysicalSummaryPage.jsx
+++ b/frontend/src/EventPhysicalSummaryPage.jsx
@@ -629,8 +629,12 @@ const [expandedRoundId, setExpandedRoundId] = useState(null);
           const resStr = forcedW
             ? "W"
             : `${r.g1.result || ""}${r.g2.result || ""}${r.g3.result || ""}`.trim();
-          const slugA = r.oppMonASlug || (typeof r.oppMonA === "object" ? r.oppMonA.slug : r.oppMonA);
-          const slugB = r.oppMonBSlug || (typeof r.oppMonB === "object" ? r.oppMonB.slug : r.oppMonB);
+          const slugA =
+            r.oppMonASlug ||
+            (r.oppMonA && typeof r.oppMonA === "object" ? r.oppMonA.slug : r.oppMonA);
+          const slugB =
+            r.oppMonBSlug ||
+            (r.oppMonB && typeof r.oppMonB === "object" ? r.oppMonB.slug : r.oppMonB);
 
           return (
             <div


### PR DESCRIPTION
## Summary
- guard against null opponent Pokémon entries when deriving slug values for round icons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a78b20bc8321a74e09dfed2abedf