### PR TITLE
Handle missing round data in computeMatchResult

### DIFF
--- a/frontend/src/EventPhysicalSummaryPage.jsx
+++ b/frontend/src/EventPhysicalSummaryPage.jsx
@@ -163,10 +163,10 @@ function normalizePokemonPair(p1, p2) {
   return `${x}/${y}`;
 }
 
-function computeMatchResult(round) {
+function computeMatchResult(round = {}) {
   const flags = round?.flags || round;
   if (flags?.bye || flags?.noShow) return "V";
-  const games = [round.g1 || {}, round.g2 || {}, round.g3 || {}];
+  const games = [round?.g1 ?? {}, round?.g2 ?? {}, round?.g3 ?? {}];
   let v = 0,
     d = 0,
     e = 0;


### PR DESCRIPTION
## Summary
- default computeMatchResult's round parameter to an empty object
- use optional chaining when building the games array to tolerate missing data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8b418fee4832189e7e8c40ff96591