### PR TITLE
Adiciona pokémons nos agregados de decks físicos

### DIFF
--- a/backend/src/physical/scripts/recomputeDeckAggregates.js
+++ b/backend/src/physical/scripts/recomputeDeckAggregates.js
@@ -1,0 +1,13 @@
+import { recomputeAllDeckAggregates } from "../aggregates.js";
+
+async function main() {
+  const processed = await recomputeAllDeckAggregates();
+  console.log(`[recomputeDeckAggregates] processed ${processed.length} decks`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error("[recomputeDeckAggregates] failed", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- coleta até dois pokémons únicos ao recalcular o agregado de decks físicos e persiste o campo nos documentos
- adiciona utilitário e script para recalcular todos os agregados existentes após o deploy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c996180c048321b543129cb7a58641