### PR TITLE
Add pokemons aggregation to live decks

### DIFF
--- a/backend/src/live/aggregates.js
+++ b/backend/src/live/aggregates.js
@@ -32,16 +32,68 @@ export async function recomputeDeck(deckKey) {
   }
   let counts = { W: 0, L: 0, T: 0 };
   let games = 0;
+  const pokemons = [];
   snap.forEach(d => {
     const ev = d.data();
     counts = countsAdd(counts, countsOfResult(ev.result));
     games += 1;
+    if (pokemons.length < 2 && Array.isArray(ev.pokemons)) {
+      for (const raw of ev.pokemons) {
+        if (pokemons.length >= 2) break;
+        let slug = null;
+        if (typeof raw === "string") {
+          slug = raw;
+        } else if (raw && typeof raw === "object") {
+          if (typeof raw.slug === "string") slug = raw.slug;
+          else if (typeof raw.name === "string") slug = raw.name;
+          else if (typeof raw.id === "string") slug = raw.id;
+        }
+        if (typeof slug === "string") {
+          const trimmed = slug.trim();
+          if (trimmed && !pokemons.includes(trimmed)) pokemons.push(trimmed);
+        }
+      }
+    }
   });
   const wr = wrPercent(counts);
   await db.collection("liveDecksAgg").doc(docId).set(
-    { deckKey, games, counts, wr },
+    { deckKey, games, counts, wr, pokemons },
     { merge: true }
   );
+}
+
+/** Recalcula todos os decks existentes em liveDecksAgg */
+export async function recomputeAllDeckAggregates() {
+  const deckKeys = new Set();
+  try {
+    const snap = await db.collection("liveDecksAgg").get();
+    snap.forEach(doc => {
+      const data = doc.data() || {};
+      let key = data.deckKey;
+      if (!key) {
+        try {
+          key = decodeURIComponent(doc.id);
+        } catch (err) {
+          console.error("[live recomputeAllDeckAggregates] failed to decode doc id", doc.id, err);
+        }
+      }
+      if (key) deckKeys.add(key);
+    });
+  } catch (err) {
+    console.error("[live recomputeAllDeckAggregates] failed to list deck keys", err);
+    return [];
+  }
+
+  const processed = [];
+  for (const key of deckKeys) {
+    try {
+      await recomputeDeck(key);
+      processed.push(key);
+    } catch (err) {
+      console.error(`[live recomputeAllDeckAggregates] failed to recompute ${key}`, err);
+    }
+  }
+  return processed;
 }
 
 /** Recalcula o agregado por oponente */

--- a/backend/src/live/scripts/recomputeDeckAggregates.js
+++ b/backend/src/live/scripts/recomputeDeckAggregates.js
@@ -1,0 +1,13 @@
+import { recomputeAllDeckAggregates } from "../aggregates.js";
+
+async function main() {
+  const processed = await recomputeAllDeckAggregates();
+  console.log(`[live recomputeDeckAggregates] processed ${processed.length} decks`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(err => {
+    console.error("[live recomputeDeckAggregates] failed", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- collect up to two pokémon identifiers while recomputing live deck aggregates
- store the pokémon list in liveDecksAgg documents and expose a helper to recompute every deck
- add a script to trigger the full recomputation for existing live deck aggregates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99af449488321a228cdb7edaa9dc9