### PR TITLE
Expose log counts in home recent logs

### DIFF
--- a/backend/src/physical/routes.js
+++ b/backend/src/physical/routes.js
@@ -11,6 +11,46 @@ const r = Router();
 
 function safeDocId(s){ try { return encodeURIComponent(String(s||"")); } catch { return String(s||"").replace(/[\/\.\#$\[\]]/g, "_"); } }
 
+function normalizeCounts(source){
+  if (!source || typeof source !== "object") return null;
+  const out = { W: 0, L: 0, T: 0 };
+  let hasValue = false;
+  for (const key of ["W","L","T"]) {
+    if (source[key] == null) continue;
+    const n = Number(source[key]);
+    if (Number.isFinite(n)) {
+      out[key] = n;
+      hasValue = true;
+    }
+  }
+  return hasValue ? out : null;
+}
+
+function countsFromResultsList(list){
+  if (!Array.isArray(list)) return null;
+  const acc = { W: 0, L: 0, T: 0 };
+  let hasValue = false;
+  for (const item of list) {
+    if (typeof item !== "string") continue;
+    const token = item.trim().toUpperCase();
+    if (!token) continue;
+    if (token === "W") { acc.W += 1; hasValue = true; }
+    else if (token === "L") { acc.L += 1; hasValue = true; }
+    else if (token === "T") { acc.T += 1; hasValue = true; }
+  }
+  return hasValue ? acc : null;
+}
+
+function eventCounts(ev = {}){
+  return (
+    normalizeCounts(ev.counts) ||
+    normalizeCounts(ev.stats?.counts) ||
+    normalizeCounts(ev.stats) ||
+    countsFromResultsList(ev.results) ||
+    countsOfResult(ev.result)
+  );
+}
+
 function normalizeNullableString(value) {
   if (value == null) return null;
   const normalized = normalizeName(value);
@@ -327,7 +367,8 @@ r.get("/events", async (req, res) => {
         playerDeck: ev.deckName || null,
         opponentDeck: ev.opponentDeck || null,
         userPokemons: ev.pokemons || ev.userPokemons || null,
-        opponentPokemons: ev.opponentPokemons || null
+        opponentPokemons: ev.opponentPokemons || null,
+        counts: eventCounts(ev),
       };
     });
     res.json(out);
@@ -365,7 +406,8 @@ r.get("/summary", async (req, res) => {
       playerDeck: ev.deckName,
       opponentDeck: ev.opponentDeck,
       userPokemons: ev.pokemons || ev.userPokemons || null,
-      opponentPokemons: ev.opponentPokemons || null
+      opponentPokemons: ev.opponentPokemons || null,
+      counts: eventCounts(ev),
     };
   });
 


### PR DESCRIPTION
## Summary
- normalize counts derived from stats/results when assembling recent logs for the home endpoint on both frontend and backend helpers
- propagate the normalized win/loss/tie totals through live and physical summaries so that widgets can consume aggregated events
- render the home Last5Days widget with WLTriplet counts, falling back to parsed result strings when explicit counts are absent

## Testing
- npm test (backend)
- npm test (frontend) *(fails: missing dependencies for server-side modules in Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a734c9f48321a678be570d185d24