### PR TITLE
Update backend notes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Backend
+- Recompute physical aggregates from round data (`backend/src/physical/aggregates.js`).
+- Add `counts` field to the `recentLogs` response of `/api/home` (`backend/src/home/routes.js`).
 - Parse debounce via frontend; backend parser improved for English short logs.
 - Suggestor filters out non-Pokémon terms.
 - `GET /api/live/events/:id` now includes `rawLog`.


### PR DESCRIPTION
## Summary
- document the recomputation of physical aggregates from rounds in the backend changelog section
- note the addition of the `counts` field to `/api/home` recent logs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9b9a7f1fc8321bb01052a3c635a5c