### PR TITLE
Combine live and physical opponent aggregates

### DIFF
--- a/frontend/src/pages/OpponentsPage.jsx
+++ b/frontend/src/pages/OpponentsPage.jsx
@@ -37,18 +37,154 @@ const renderWLChip = (r) => {
 };
 
 /* ---------- mappers ---------- */
-function mapOpponent(item) {
-  const counts = item?.counts || { W: 0, L: 0, T: 0 };
-  const top = item?.topDeck || null;
+function normalizeCounts(counts = {}) {
   return {
-    name: item?.opponentName || item?.name || item?.opponent || "",
-    wr: Number(item?.wr) || 0,
-    counts: { W: counts.W || 0, L: counts.L || 0, T: counts.T || 0 },
-    topDeckKey: top?.deckKey || "",
-    topDeckName: top?.deckName || "",
-    topPokemons: Array.isArray(top?.pokemons) ? top.pokemons : undefined,
+    W: Number(counts?.W) || 0,
+    L: Number(counts?.L) || 0,
+    T: Number(counts?.T) || 0,
   };
 }
+
+function sumCounts(a = {}, b = {}) {
+  const A = normalizeCounts(a);
+  const B = normalizeCounts(b);
+  return { W: A.W + B.W, L: A.L + B.L, T: A.T + B.T };
+}
+
+function wrFromCounts({ W = 0, L = 0, T = 0 } = {}) {
+  const total = W + L + T;
+  if (!total) return 0;
+  return Math.round((W / total) * 1000) / 10;
+}
+
+function normalizeWr(raw, counts) {
+  const n = Number(raw);
+  if (Number.isFinite(n)) {
+    const clamped = Math.max(0, Math.min(100, n));
+    return Math.round(clamped * 10) / 10;
+  }
+  return wrFromCounts(counts);
+}
+
+function normalizeTopDeck(raw) {
+  if (!raw) return undefined;
+  const deckKey = raw.deckKey ? String(raw.deckKey).trim() : "";
+  const deckName = raw.deckName ? String(raw.deckName).trim() : "";
+  const pokemons = Array.isArray(raw.pokemons) ? [...raw.pokemons] : undefined;
+  if (!deckKey && !deckName && !(pokemons && pokemons.length)) return undefined;
+  return { deckKey, deckName, pokemons: pokemons && pokemons.length ? pokemons : undefined };
+}
+
+function deckCompleteness(deck) {
+  if (!deck) return 0;
+  let score = 0;
+  if (deck.deckKey) score += 3;
+  if (deck.deckName) score += 2;
+  if (Array.isArray(deck.pokemons) && deck.pokemons.length) score += 1;
+  return score;
+}
+
+function mergeTopDecks(prev, next) {
+  const a = normalizeTopDeck(prev);
+  const b = normalizeTopDeck(next);
+  if (!a && !b) return undefined;
+  if (!a) return b;
+  if (!b) return a;
+
+  const [primary, secondary] = deckCompleteness(b) > deckCompleteness(a) ? [b, a] : [a, b];
+  const merged = {
+    deckKey: primary.deckKey || secondary.deckKey || "",
+    deckName: primary.deckName || secondary.deckName || "",
+    pokemons:
+      Array.isArray(primary.pokemons) && primary.pokemons.length
+        ? [...primary.pokemons]
+        : Array.isArray(secondary.pokemons) && secondary.pokemons.length
+          ? [...secondary.pokemons]
+          : undefined,
+  };
+  return normalizeTopDeck(merged);
+}
+
+function applyTopDeck(opponent, deck) {
+  const normalizedDeck = normalizeTopDeck(deck);
+  return {
+    ...opponent,
+    topDeck: normalizedDeck,
+    topDeckKey: normalizedDeck?.deckKey || "",
+    topDeckName: normalizedDeck?.deckName || "",
+    topPokemons: normalizedDeck?.pokemons,
+  };
+}
+
+function buildOpponent({ name = "", counts = {}, wr, topDeck }) {
+  const safeCounts = normalizeCounts(counts);
+  const safeWr = normalizeWr(wr, safeCounts);
+  return applyTopDeck(
+    {
+      name,
+      counts: safeCounts,
+      wr: safeWr,
+    },
+    topDeck
+  );
+}
+
+function cloneOpponent(item) {
+  if (!item) return buildOpponent({ name: "", counts: {} });
+  return buildOpponent({ name: item.name, counts: item.counts, wr: item.wr, topDeck: item.topDeck });
+}
+
+function extractTopDeck(item = {}) {
+  const top = typeof item.topDeck === "object" && item.topDeck ? item.topDeck : {};
+  const pokemonsSource =
+    top.pokemons ?? item.topPokemons ?? item.pokemons ?? item.spriteIds;
+  return normalizeTopDeck({
+    deckKey: top.deckKey || item.topDeckKey || item.deckKey || "",
+    deckName: top.deckName || item.topDeckName || item.deckName || "",
+    pokemons: Array.isArray(pokemonsSource) ? pokemonsSource : undefined,
+  });
+}
+
+function mapOpponent(item) {
+  const counts = normalizeCounts(item?.counts);
+  const name = String(item?.opponentName || item?.name || item?.opponent || "").trim();
+  return buildOpponent({
+    name,
+    counts,
+    wr: normalizeWr(item?.wr, counts),
+    topDeck: extractTopDeck(item),
+  });
+}
+
+function combineOpponents(list) {
+  const grouped = new Map();
+  for (const item of list) {
+    if (!item?.name) continue;
+    const existing = grouped.get(item.name);
+    if (!existing) {
+      grouped.set(item.name, {
+        name: item.name,
+        counts: normalizeCounts(item.counts),
+        topDeck: normalizeTopDeck(item.topDeck),
+      });
+      continue;
+    }
+    const counts = sumCounts(existing.counts, item.counts);
+    const topDeck = mergeTopDecks(existing.topDeck, item.topDeck);
+    grouped.set(item.name, { name: item.name, counts, topDeck });
+  }
+  return Array.from(grouped.values())
+    .map((entry) =>
+      buildOpponent({
+        name: entry.name,
+        counts: entry.counts,
+        wr: wrFromCounts(entry.counts),
+        topDeck: entry.topDeck,
+      })
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 function mapLog(x, opponentName) {
   return {
     id: x.id || x._id || x.logId || `${opponentName}-${x.date || Math.random()}`,
@@ -85,20 +221,49 @@ export default function OpponentsPage() {
     let alive = true;
 
     async function enrichTopDecksFromLogs(list) {
-      const targets = list.filter(r => !r.topDeckKey && !r.topDeckName).slice(0, 20);
-      await Promise.all(
-        targets.map(async (r) => {
+      const targets = list.filter((r) => !r.topDeckKey && !r.topDeckName).slice(0, 20);
+      if (!targets.length) return list.map((item) => cloneOpponent(item));
+
+      const updates = await Promise.all(
+        targets.map(async (item) => {
           try {
-            const res = await getOpponentLogs(r.name, { limit: 1, offset: 0 });
-            const arr = Array.isArray(res?.rows) ? res.rows : (Array.isArray(res) ? res : []);
+            const res = await getOpponentLogs(item.name, { limit: 1, offset: 0 });
+            const arr = Array.isArray(res?.rows) ? res.rows : Array.isArray(res) ? res : [];
             const first = arr[0];
+            if (!first) return null;
             const deckStr = first?.opponentDeck || first?.oppDeck || "";
             const dk = toDeckKey(deckStr || "");
-            if (dk) r.topDeckKey = dk;
-          } catch {}
+            if (!dk) return null;
+            const pokemons = first?.opponentPokemons || first?.oppPokemons;
+            const deck = normalizeTopDeck({
+              deckKey: dk,
+              deckName: deckStr || "",
+              pokemons: Array.isArray(pokemons) ? pokemons : undefined,
+            });
+            if (!deck) return null;
+            return { name: item.name, topDeck: deck };
+          } catch {
+            return null;
+          }
         })
       );
-      return list.map(r => ({ ...r }));
+
+      const updateMap = new Map();
+      for (const entry of updates) {
+        if (!entry?.name || !entry.topDeck) continue;
+        updateMap.set(entry.name, entry.topDeck);
+      }
+
+      return list.map((item) => {
+        const updateDeck = updateMap.get(item.name);
+        const mergedDeck = mergeTopDecks(item.topDeck, updateDeck);
+        return buildOpponent({
+          name: item.name,
+          counts: item.counts,
+          wr: item.wr,
+          topDeck: mergedDeck,
+        });
+      });
     }
 
     (async () => {
@@ -107,10 +272,11 @@ export default function OpponentsPage() {
         const payload = await getOpponentsAgg();
         const arr = Array.isArray(payload) ? payload : Array.isArray(payload?.rows) ? payload.rows : [];
         const mapped = arr.map(mapOpponent).filter(r => r.name);
+        const combined = combineOpponents(mapped);
         if (!alive) return;
 
-        setAll(mapped);
-        const enriched = await enrichTopDecksFromLogs(mapped);
+        setAll(combined);
+        const enriched = await enrichTopDecksFromLogs(combined);
         if (!alive) return;
         setAll(enriched);
       } catch (e) {


### PR DESCRIPTION
## Summary
- add a physical aggregate wrapper and combine live/physical opponent payloads in the API service
- normalize and merge opponent rows on the page, recomputing totals/wr and preferring the richest top-deck metadata
- update the top-deck enrichment helper to work on the unified list without mutating existing state

## Testing
- npm run lint *(fails: project has many pre-existing lint errors about undefined globals)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c2f7fc00832183f01247f47f1f17