### PR TITLE
Expose pokemon hints in physical logs

### DIFF
--- a/backend/src/physical/routes.test.js
+++ b/backend/src/physical/routes.test.js
@@ -470,6 +470,8 @@ describe("physical routes GET /logs", () => {
       result: "W",
       source: "physical",
     });
+    expect(row.userPokemons).toEqual(["pikachu"]);
+    expect(row.opponentPokemons).toEqual(["machamp"]);
     expect(row.pokemons).toEqual(expect.arrayContaining(["pikachu", "machamp"]));
     expect(row.event ?? row.eventName).toBe("League Challenge");
   });
@@ -511,6 +513,8 @@ describe("physical routes GET /logs", () => {
       result: "L",
       source: "physical",
     });
+    expect(row.userPokemons).toEqual(["charizard"]);
+    expect(row.opponentPokemons).toEqual(["ekans"]);
     expect(row.pokemons).toEqual(expect.arrayContaining(["charizard", "ekans"]));
   });
 


### PR DESCRIPTION
## Summary
- add helper to pick player pokemon hints from stored events and carry them in /api/physical/logs rows
- surface opponent pokemon suggestions from aggregates/rounds while cloning hints into each row
- extend physical logs tests to cover new userPokemons and opponentPokemons fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e55761b883218c9a4359b6a4146f