### PR TITLE
Adjust Resumo Geral top deck label icons

### DIFF
--- a/frontend/src/components/DeckLabel.jsx
+++ b/frontend/src/components/DeckLabel.jsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { resolveIconsFromDeck } from "../services/pokemonIcons.js";
 
-export default function DeckLabel({ deckName, pokemonHints, stacked = false, className = "" }) {
+export default function DeckLabel({
+  deckName,
+  pokemonHints,
+  stacked = false,
+  className = "",
+  showIcons = true,
+}) {
   const [icons, setIcons] = useState([]);
 
   const candidates = useMemo(() => {
@@ -11,6 +17,11 @@ export default function DeckLabel({ deckName, pokemonHints, stacked = false, cla
   }, [deckName, pokemonHints]);
 
   useEffect(() => {
+    if (!showIcons) {
+      setIcons([]);
+      return;
+    }
+
     let alive = true;
     (async () => {
       try {
@@ -20,32 +31,39 @@ export default function DeckLabel({ deckName, pokemonHints, stacked = false, cla
         if (alive) setIcons([]);
       }
     })();
-    return () => { alive = false; };
-  }, [candidates]);
+    return () => {
+      alive = false;
+    };
+  }, [candidates, showIcons]);
 
-  const imgs = icons.slice(0, 2).map((src, idx) => (
-    <img
-      key={idx}
-      src={src}
-      alt=""
-      className="h-[18px] w-[18px] rounded-full ring-1 ring-zinc-800/60 object-cover shrink-0"
-      loading="lazy"
-      decoding="async"
-    />
-  ));
+  const imgs = showIcons
+    ? icons.slice(0, 2).map((src, idx) => (
+        <img
+          key={idx}
+          src={src}
+          alt=""
+          className="h-[18px] w-[18px] rounded-full ring-1 ring-zinc-800/60 object-cover shrink-0"
+          loading="lazy"
+          decoding="async"
+        />
+      ))
+    : [];
 
   if (stacked) {
     // Exibe em 2 linhas quando o nome do deck é composto (A / B)
     const [a, b] = String(deckName || "").split(" / ");
+    const firstIcon = showIcons ? imgs[0] : null;
+    const secondIcon = showIcons ? imgs[1] : null;
+
     return (
       <div className={`min-w-0 flex flex-col gap-1 ${className}`}>
         <div className="flex items-center gap-2 min-w-0">
-          {imgs[0]}
+          {firstIcon}
           <span className="truncate">{a || deckName}</span>
         </div>
-        { (b || imgs[1]) && (
+        {(b || secondIcon) && (
           <div className="flex items-center gap-2 min-w-0">
-            {imgs[1]}
+            {secondIcon}
             <span className="truncate">{b}</span>
           </div>
         )}
@@ -55,7 +73,7 @@ export default function DeckLabel({ deckName, pokemonHints, stacked = false, cla
 
   return (
     <div className={`min-w-0 flex items-center gap-2 ${className}`}>
-      {imgs}
+      {showIcons && imgs}
       <span className="truncate">{deckName}</span>
     </div>
   );

--- a/frontend/src/components/widgets/ResumoGeralWidget.jsx
+++ b/frontend/src/components/widgets/ResumoGeralWidget.jsx
@@ -21,20 +21,20 @@ export default function ResumoGeralWidget({ title, variant, winRate, center, top
   const isDatasLive = variant === "datasLive";
 
   const TopDeckContent = (
-    <div className="flex items-center justify-end gap-3">
-      <div className="flex -space-x-3">
-        {(topDeck?.avatars || []).slice(0, 2).map((src, i) => (
-          <img
-            key={i}
-            src={src}
-            alt="avatar"
-            className="h-10 w-10 rounded-full ring-2 ring-zinc-900 object-cover"
-          />
-        ))}
-      </div>
+    <div className="flex justify-end">
       <div className="text-right">
-        <div className={`text-sm font-medium leading-tight ${isDatasLive ? 'whitespace-normal break-words max-w-none' : 'truncate '} ${isFisico ? '' : ''}` }>
-        <DeckLabel deckName={topDeck?.deckName} pokemonHints={topDeck?.pokemons} stacked />
+        <div
+          className={`text-sm font-medium leading-tight ${
+            isDatasLive ? "whitespace-normal break-words max-w-none" : "truncate"
+          }`}
+        >
+          <DeckLabel
+            deckName={topDeck?.deckName}
+            pokemonHints={topDeck?.pokemons}
+            stacked
+            showIcons={false}
+            className="items-end text-right"
+          />
         </div>
         <div className="text-xs text-zinc-400">
           Top Deck • <span className="text-zinc-200 font-medium">{(topDeck?.winRate ?? 0).toFixed(1)}% WR</span>


### PR DESCRIPTION
## Summary
- add a `showIcons` flag to `DeckLabel` so icon resolution and rendering can be skipped when not needed
- update the Resumo Geral widget to hide deck icons and keep the top-deck text aligned to the right

## Testing
- npm run lint *(fails: existing lint violations in unrelated legacy files)*
- Manual verification of Resumo Geral widget on #/, #/tcg-live and #/tcg-fisico

------
https://chatgpt.com/codex/tasks/task_e_68c9eb9e6b348321a8d36ceb87c231e5