### PR TITLE
Enable deck icons in ResumoGeralWidget

### DIFF
--- a/frontend/src/components/widgets/ResumoGeralWidget.jsx
+++ b/frontend/src/components/widgets/ResumoGeralWidget.jsx
@@ -32,7 +32,6 @@ export default function ResumoGeralWidget({ title, variant, winRate, center, top
             deckName={topDeck?.deckName}
             pokemonHints={topDeck?.pokemons}
             stacked
-            showIcons={false}
             className="items-end text-right"
           />
         </div>


### PR DESCRIPTION
## Summary
- re-enable deck icons in the ResumoGeralWidget top-deck label by letting DeckLabel use its default behaviour

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eda1733483218bb9fcc07a7cfb68