### PR TITLE
Fix physical logs comparator timestamp fallback

### DIFF
--- a/backend/src/physical/routes.js
+++ b/backend/src/physical/routes.js
@@ -1343,7 +1343,7 @@ r.get("/logs", async (req, res) => {
 
     rows.sort((a, b) => {
       const aTs = typeof a.ts === "number" && Number.isFinite(a.ts) ? a.ts : computeEventTimestamp(a);
-      const bTs = typeof b.ts === "number" && Number.isFinite(b.ts) ? bTs : computeEventTimestamp(b);
+      const bTs = typeof b.ts === "number" && Number.isFinite(b.ts) ? b.ts : computeEventTimestamp(b);
       return bTs - aTs;
     });
 


### PR DESCRIPTION
## Summary
- fix the /physical/logs sorting comparator to use the document timestamp when `b.ts` is present and fall back to `computeEventTimestamp`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f65043c883218899b8566ecd84bd