### PR TITLE
Add hover highlight to opponent log rows

### DIFF
--- a/frontend/src/pages/OpponentsPage.jsx
+++ b/frontend/src/pages/OpponentsPage.jsx
@@ -452,7 +452,7 @@ export default function OpponentsPage() {
                       <a
                         key={log.id}
                         href={buildLogHref(log)}
-                        className="grid grid-cols-12 items-center gap-2 py-2 text-sm"
+                        className="grid grid-cols-12 items-center gap-2 py-2 text-sm transition-colors hover:bg-zinc-900/50"
                       >
                         <div className="col-span-2">{log.date}</div>
                         <div className="col-span-4">


### PR DESCRIPTION
## Summary
- add hover/transition styling to opponent log links so expanded rows highlight on hover for consistency with Decks Live

## Testing
- npm run lint *(fails: existing lint issues across unrelated files)*
- Verified hover highlight manually in the Opponents page (dev server + mocked API)


------
https://chatgpt.com/codex/tasks/task_e_68c9faefa4f08321a10fa84934db7604