### PR TITLE
Normalize physical match stats counting

### DIFF
--- a/frontend/src/PhysicalPageV2.helpers.test.js
+++ b/frontend/src/PhysicalPageV2.helpers.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./components/NovoRegistroDialog.jsx", () => ({ default: () => null }));
+vi.mock("./components/widgets/ResumoGeralWidget.jsx", () => ({ default: () => null }));
+vi.mock("./components/DeckLabel.jsx", () => ({ default: () => null }));
+vi.mock("./eventsRepo.js", () => ({ getEvent: vi.fn() }));
+vi.mock("./services/api.js", () => ({
+  getPhysicalLogs: vi.fn(),
+  getPhysicalSummary: vi.fn(),
+  normalizeDeckKey: (value) => value,
+}));
+vi.mock("framer-motion", () => ({ motion: { div: () => null } }));
+vi.mock("lucide-react", () => ({
+  BarChart3: () => null,
+  CalendarDays: () => null,
+  Trophy: () => null,
+  Users: () => null,
+  Upload: () => null,
+}));
+
+import { countsFrom, topDeckByWinRate, winRate } from "./PhysicalPageV2.jsx";
+
+describe("PhysicalPageV2 helper utilities", () => {
+  it("countsFrom normaliza tokens variados de resultado", () => {
+    const matches = [
+      { result: "W" },
+      { result: "w" },
+      { result: "win" },
+      { result: "V" },
+      { result: "L" },
+      { result: "loss" },
+      { result: "D" },
+      { result: "T" },
+      { result: "tie" },
+      { result: "empate" },
+      { result: "" },
+      { result: "unknown" },
+      {},
+    ];
+    expect(countsFrom(matches)).toEqual({ W: 4, L: 3, T: 3, total: 10 });
+  });
+
+  it("winRate inclui empates no denominador", () => {
+    expect(winRate({ W: 7, L: 2, T: 1 })).toBe(70);
+    expect(winRate({})).toBe(0);
+  });
+
+  it("topDeckByWinRate considera tokens normalizados e desempata por volume", () => {
+    const matches = [
+      { playerDeck: "Alpha", result: "win" },
+      { playerDeck: "Alpha", result: "loss" },
+      { playerDeck: "Alpha", result: "empate" },
+      { playerDeck: "Beta", result: "W" },
+      { playerDeck: "Beta", result: "L" },
+      { playerDeck: "Beta", result: "V" },
+      { playerDeck: "Beta", result: "T" },
+      { playerDeck: "Gamma", result: "w" },
+      { playerDeck: "Gamma", result: "d" },
+      { playerDeck: "Delta", result: "BYE" },
+    ];
+
+    const best = topDeckByWinRate(matches);
+    expect(best).toMatchObject({ deckKey: "Beta", winRate: 50, games: 4 });
+  });
+});


### PR DESCRIPTION
## Summary
- normalize physical match counters to handle W/L/T tokens consistently
- reuse the normalized counts when computing win rates and the manual top deck pick
- add vitest coverage ensuring helper utilities handle mixed result tokens and deck tie-breakers

## Testing
- npm test -- PhysicalPageV2.helpers.test.js
- npm test *(fails: requires optional dependencies node-fetch/express in vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ca11c3961083219f0bd5ee40c9b966