### PR TITLE
Ajusta cálculo manual do resumo físico

### DIFF
--- a/frontend/src/PhysicalPageV2.jsx
+++ b/frontend/src/PhysicalPageV2.jsx
@@ -674,8 +674,24 @@ export default function PhysicalPageV2({ manualMatches }) {
   const manualWinRate = useMemo(() => winRate(manualCounts), [manualCounts]);
   const summaryCounts = summaryData?.summary?.counts;
   const summaryWinRate = typeof summaryData?.summary?.wr === "number" ? summaryData.summary.wr : null;
-  const totalMatches = summaryCounts?.total ?? manualCounts.total ?? manual.length;
-  const displayWinRate = summaryWinRate ?? manualWinRate;
+  const hasManualMatches = manual.length > 0;
+  const summaryTotal = typeof summaryCounts?.total === "number" ? summaryCounts.total : null;
+  const hasValidSummaryCounts = typeof summaryTotal === "number" && summaryTotal > 0;
+  const manualTotal = typeof manualCounts?.total === "number" ? manualCounts.total : 0;
+
+  const totalMatches = hasManualMatches
+    ? manualTotal > 0
+      ? manualTotal
+      : manual.length
+    : hasValidSummaryCounts
+    ? summaryTotal
+    : manualTotal;
+
+  const displayWinRate = hasManualMatches
+    ? manualWinRate
+    : hasValidSummaryCounts && typeof summaryWinRate === "number"
+    ? summaryWinRate
+    : manualWinRate;
 
   const topDeckComputed = useMemo(() => topDeckByWinRate(manual), [manual]);
   const summaryTopDeck = summaryData?.summary?.topDeck || null;


### PR DESCRIPTION
## Summary
- prioriza contagens e win rate calculados a partir dos logs físicos carregados
- usa os valores recalculados ao preencher o widget de resumo, inclusive em cenários apenas com dados manuais

## Testing
- npm run lint *(fails: existing no-undef/import-order warnings em arquivos não relacionados)*
- verificação visual do widget com dados manuais e resumo agregado zerado

------
https://chatgpt.com/codex/tasks/task_e_68ca18949d0483218d5f0bc4214edf30