### PR TITLE
Aggregate top deck Pokémon hints

### DIFF
--- a/frontend/src/PhysicalPageV2.helpers.test.js
+++ b/frontend/src/PhysicalPageV2.helpers.test.js
@@ -18,7 +18,7 @@ vi.mock("lucide-react", () => ({
   Upload: () => null,
 }));
 
-import { countsFrom, topDeckByWinRate, winRate } from "./PhysicalPageV2.jsx";
+import { aggregatePokemonHintsForDeck, countsFrom, topDeckByWinRate, winRate } from "./PhysicalPageV2.jsx";
 
 describe("PhysicalPageV2 helper utilities", () => {
   it("countsFrom normaliza tokens variados de resultado", () => {
@@ -61,5 +61,23 @@ describe("PhysicalPageV2 helper utilities", () => {
 
     const best = topDeckByWinRate(matches);
     expect(best).toMatchObject({ deckKey: "Beta", winRate: 50, games: 4 });
+  });
+
+  it("aggregatePokemonHintsForDeck combina todas as entradas do deck vencedor", () => {
+    const matches = [
+      { playerDeck: "Alpha", userPokemons: ["gardevoir", "mewtwo"] },
+      { playerDeck: "Alpha", userPokemons: ["gardevoir", "miraidon"] },
+      { playerDeck: "Beta", userPokemons: ["charizard"] },
+      { playerDeck: "Alpha", userPokemons: ["gardevoir", "zacian", "mewtwo"] },
+      { playerDeck: "Alpha", userPokemons: ["  Gardevoir  "] },
+    ];
+
+    const hints = aggregatePokemonHintsForDeck(matches, "Alpha");
+    expect(hints).toEqual(["gardevoir", "mewtwo", "miraidon", "zacian"]);
+  });
+
+  it("aggregatePokemonHintsForDeck retorna vazio quando não encontra correspondências", () => {
+    expect(aggregatePokemonHintsForDeck([], "Gamma")).toEqual([]);
+    expect(aggregatePokemonHintsForDeck([{ playerDeck: "Alpha", userPokemons: ["lugia"] }], "Gamma")).toEqual([]);
   });
 });

--- a/frontend/src/services/pokemonIcons.js
+++ b/frontend/src/services/pokemonIcons.js
@@ -92,6 +92,23 @@ export async function resolveIconsFromDeck(deckName, pokemonHints) {
     pokemonHints.filter(Boolean).slice(0,2).forEach(push);
   }
 
+  if (!candidates.length && deckName) {
+    const base = String(deckName || "");
+    const cleanedSeparators = base
+      .replace(/\s+vs\.?\s+/gi, "/")
+      .replace(/\s+x\s+/gi, "/")
+      .replace(/\s+&\s+/g, "/");
+    cleanedSeparators
+      .split(/[\/]/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach(push);
+
+    if (!candidates.length) {
+      push(base);
+    }
+  }
+
   // Final safety: only valid slugs
   const valid = candidates.filter(s => /^[a-z0-9-]+$/.test(s));
   const out = await Promise.all((valid.length ? valid : [""]).slice(0,2).map(getPokemonIcon));


### PR DESCRIPTION
## Summary
- add an aggregation helper that derives top-deck Pokémon hints from all matching manual logs and use it when summary avatars are missing
- extend the helper test suite to cover the aggregation behaviour
- improve `resolveIconsFromDeck` to derive icon slugs from deck names when hints are unavailable

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68cb0bd289a883219bbc9a9f5762337f