### PR TITLE
Prioritize manual hint aggregation for top deck display

### DIFF
--- a/frontend/src/PhysicalPageV2.helpers.test.js
+++ b/frontend/src/PhysicalPageV2.helpers.test.js
@@ -18,7 +18,13 @@ vi.mock("lucide-react", () => ({
   Upload: () => null,
 }));
 
-import { aggregatePokemonHintsForDeck, countsFrom, topDeckByWinRate, winRate } from "./PhysicalPageV2.jsx";
+import {
+  aggregatePokemonHintsForDeck,
+  countsFrom,
+  deriveTopDeckHints,
+  topDeckByWinRate,
+  winRate,
+} from "./PhysicalPageV2.jsx";
 
 describe("PhysicalPageV2 helper utilities", () => {
   it("countsFrom normaliza tokens variados de resultado", () => {
@@ -79,5 +85,22 @@ describe("PhysicalPageV2 helper utilities", () => {
   it("aggregatePokemonHintsForDeck retorna vazio quando não encontra correspondências", () => {
     expect(aggregatePokemonHintsForDeck([], "Gamma")).toEqual([]);
     expect(aggregatePokemonHintsForDeck([{ playerDeck: "Alpha", userPokemons: ["lugia"] }], "Gamma")).toEqual([]);
+  });
+
+  it("deriveTopDeckHints prioriza agregação manual em relação ao resumo", () => {
+    const matches = [
+      { playerDeck: "Alpha", userPokemons: ["gardevoir"] },
+      { playerDeck: "Alpha", userPokemons: ["zacian"] },
+    ];
+
+    const summaryTopDeck = { deckKey: "Alpha", avatars: ["lugia"] };
+
+    const hints = deriveTopDeckHints({
+      matches,
+      summaryTopDeck,
+      deckKeyCandidates: ["Alpha", "alpha", "—"],
+    });
+
+    expect(hints).toEqual(["gardevoir", "zacian"]);
   });
 });


### PR DESCRIPTION
## Summary
- add a deriveTopDeckHints helper that favors aggregated manual hints before summary avatars
- update PhysicalPageV2 to reuse the helper while keeping deck key candidate normalization
- cover the precedence rules with a new PhysicalPageV2 helpers unit test

## Testing
- npm test -- PhysicalPageV2.helpers

------
https://chatgpt.com/codex/tasks/task_e_68cb15d00c708321a125f326b3baff9e