### PR TITLE
Adjust deck label stacking logic

### DIFF
--- a/frontend/src/components/DeckLabel.jsx
+++ b/frontend/src/components/DeckLabel.jsx
@@ -49,9 +49,14 @@ export default function DeckLabel({
       ))
     : [];
 
-  if (stacked) {
-    // Exibe em 2 linhas quando o nome do deck é composto (A / B)
-    const [a, b] = String(deckName || "").split(" / ");
+  const normalizedName = typeof deckName === "string" ? deckName : "";
+  const [firstSegmentRaw, ...restSegmentsRaw] = normalizedName.split(" / ");
+  const firstSegment = firstSegmentRaw?.trim?.() ?? "";
+  const restSegments = restSegmentsRaw.map((segment) => (segment ?? "").trim());
+  const secondSegment = restSegments.join(" / ").trim();
+  const hasSecondSegment = secondSegment.length > 0;
+
+  if (stacked && hasSecondSegment) {
     const firstIcon = showIcons ? imgs[0] : null;
     const secondIcon = showIcons ? imgs[1] : null;
 
@@ -59,22 +64,22 @@ export default function DeckLabel({
       <div className={`min-w-0 flex flex-col gap-1 ${className}`}>
         <div className="flex items-center gap-2 min-w-0">
           {firstIcon}
-          <span className="truncate">{a || deckName}</span>
+          <span className="truncate">{firstSegment || normalizedName}</span>
         </div>
-        {(b || secondIcon) && (
-          <div className="flex items-center gap-2 min-w-0">
-            {secondIcon}
-            <span className="truncate">{b}</span>
-          </div>
-        )}
+        <div className="flex items-center gap-2 min-w-0">
+          {secondIcon}
+          <span className="truncate">{secondSegment}</span>
+        </div>
       </div>
     );
   }
 
+  const inlineLabel = stacked ? firstSegment || normalizedName : deckName;
+
   return (
     <div className={`min-w-0 flex items-center gap-2 ${className}`}>
       {showIcons && imgs}
-      <span className="truncate">{deckName}</span>
+      <span className="truncate">{inlineLabel}</span>
     </div>
   );
 }

--- a/frontend/src/components/DeckLabel.test.jsx
+++ b/frontend/src/components/DeckLabel.test.jsx
@@ -55,4 +55,26 @@ describe("DeckLabel", () => {
     expect(imgs[0].getAttribute("src")).toBe("https://img/chien-pao.png");
     expect(imgs[1].getAttribute("src")).toBe("https://img/baxcalibur.png");
   });
+
+  it("renders stacked layout for multi-segment deck names", () => {
+    render(<DeckLabel deckName="Arceus / Giratina" stacked showIcons={false} />);
+
+    const firstLine = screen.getByText("Arceus");
+    const secondLine = screen.getByText("Giratina");
+
+    const container = firstLine.closest("div")?.parentElement;
+    expect(container?.className).toContain("flex-col");
+    expect(container?.querySelectorAll("span.truncate")).toHaveLength(2);
+    expect(secondLine.closest("div")?.parentElement).toBe(container);
+  });
+
+  it("keeps inline layout for single-segment deck names", () => {
+    render(<DeckLabel deckName="Lugia VSTAR" showIcons={false} />);
+
+    const label = screen.getByText("Lugia VSTAR");
+    const container = label.closest("div");
+
+    expect(container?.className).not.toContain("flex-col");
+    expect(container?.querySelectorAll("span.truncate")).toHaveLength(1);
+  });
 });

--- a/frontend/src/components/widgets/ResumoGeralWidget.jsx
+++ b/frontend/src/components/widgets/ResumoGeralWidget.jsx
@@ -20,6 +20,13 @@ export default function ResumoGeralWidget({ title, variant, winRate, center, top
   const isFisico = variant === "fisico";
   const isDatasLive = variant === "datasLive";
 
+  const topDeckName = typeof topDeck?.deckName === "string" ? topDeck.deckName : "";
+  const topDeckNameSegments = topDeckName
+    .split(" / ")
+    .slice(1)
+    .map((segment) => segment.trim());
+  const shouldStackTopDeck = topDeckNameSegments.some((segment) => segment.length > 0);
+
   const TopDeckContent = (
     <div className="flex justify-end">
       <div className="text-right">
@@ -31,7 +38,7 @@ export default function ResumoGeralWidget({ title, variant, winRate, center, top
           <DeckLabel
             deckName={topDeck?.deckName}
             pokemonHints={topDeck?.pokemons}
-            stacked
+            stacked={shouldStackTopDeck}
             className="items-end text-right"
           />
         </div>


### PR DESCRIPTION
## Summary
- compute whether the top deck label should use the stacked layout by inspecting the deck name
- ensure DeckLabel only renders the stacked two-line layout when a second segment is present and keep the inline fallback
- cover both stacked and inline deck names in the DeckLabel unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb176875948321964df56f6f7dbf60