### PR TITLE
Filter Local League widget to store-based matches

### DIFF
--- a/frontend/src/PhysicalPageV2.helpers.test.js
+++ b/frontend/src/PhysicalPageV2.helpers.test.js
@@ -22,6 +22,7 @@ import {
   aggregatePokemonHintsForDeck,
   countsFrom,
   deriveTopDeckHints,
+  selectStoreFocusedMatches,
   topDeckByWinRate,
   winRate,
 } from "./PhysicalPageV2.jsx";
@@ -102,5 +103,20 @@ describe("PhysicalPageV2 helper utilities", () => {
     });
 
     expect(hints).toEqual(["gardevoir", "zacian"]);
+  });
+
+  it("selectStoreFocusedMatches descarta partidas sem loja e normaliza tipo", () => {
+    const matches = [
+      { id: "withLocal", storeName: "Liga Center", eventType: "Liga Local" },
+      { id: "noStore", eventType: "Liga Local" },
+      { id: "blankStore", storeName: "   ", eventType: "cup" },
+      { id: "regional", storeName: "Regional Hub", eventType: "regional" },
+      { id: "challenge", storeName: "Challenge HQ", eventType: "Challenge" },
+      { id: "cup", storeName: "Cup Place", eventType: "CUP" },
+    ];
+
+    const filtered = selectStoreFocusedMatches(matches);
+
+    expect(filtered.map((m) => m.id)).toEqual(["withLocal", "challenge", "cup"]);
   });
 });

--- a/frontend/src/PhysicalPageV2.jsx
+++ b/frontend/src/PhysicalPageV2.jsx
@@ -532,10 +532,29 @@ const TournamentsSummaryWidget = ({ manualMatches }) => {
   );
 };
 
+const STORE_FOCUSED_EVENT_TYPES = new Set(["local", "challenge", "cup"]);
+
+const normalizeStoreEventType = (value) => {
+  const raw = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (STORE_FOCUSED_EVENT_TYPES.has(raw)) return raw;
+  const normalized = normalizeEventTypeKey(value);
+  if (normalized && STORE_FOCUSED_EVENT_TYPES.has(normalized)) return normalized;
+  return null;
+};
+
+export const selectStoreFocusedMatches = (manualMatches = []) =>
+  (Array.isArray(manualMatches) ? manualMatches : [])
+    .filter((match) => {
+      if (!match) return false;
+      const storeName = typeof match.storeName === "string" ? match.storeName.trim() : "";
+      if (!storeName) return false;
+      const eventTypeKey = normalizeStoreEventType(match.eventType ?? match.type);
+      return Boolean(eventTypeKey);
+    });
+
 const LocalLeagueWidget = ({ manualMatches }) => {
-  const rows = useMemo(() => (manualMatches || [])
-    .filter(m => m.eventType === 'local')
-    .sort((a,b) => b.date - a.date)
+  const rows = useMemo(() => selectStoreFocusedMatches(manualMatches)
+    .sort((a,b) => (b?.date || 0) - (a?.date || 0))
     .slice(0,5), [manualMatches]);
 
   return (


### PR DESCRIPTION
## Summary
- filter Liga Local widget rows to only include store-focused event types with a store name
- expose a helper to share the filtering logic and reuse it in LocalLeagueWidget
- extend PhysicalPageV2 helper tests to cover the new filtering behavior

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc31b880b8832191b802d91ae660d2