### PR TITLE
Improve physical store events listing

### DIFF
--- a/frontend/src/PhysicalPageV2.jsx
+++ b/frontend/src/PhysicalPageV2.jsx
@@ -532,7 +532,7 @@ const TournamentsSummaryWidget = ({ manualMatches }) => {
   );
 };
 
-const STORE_FOCUSED_EVENT_TYPES = new Set(["local", "challenge", "cup"]);
+export const STORE_FOCUSED_EVENT_TYPES = new Set(["local", "challenge", "cup"]);
 
 const normalizeStoreEventType = (value) => {
   const raw = typeof value === "string" ? value.trim().toLowerCase() : "";


### PR DESCRIPTION
## Summary
- reuse the store-focused event type constant in PhysicalStoreEventsPage and enrich the log aggregation with normalized deck metadata
- render store listings with totals, a new Store column, and collapsible match details that cache fetched rounds per event
- feed DeckLabel with normalized keys and pokemon hints so expanded rows surface opponent and player decks alongside match results

## Testing
- `npm run lint` *(fails: project-wide missing global definitions such as console/fetch/process in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc40b65d748321899296553c465968