### PR TITLE
Add date-fns dependency to frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ptcg-premium-app-merged",
       "version": "1.0.0",
       "dependencies": {
+        "date-fns": "^3.6.0",
         "framer-motion": "^11.0.0",
         "lucide-react": "^0.453.0",
         "prop-types": "^15.8.1",
@@ -2841,6 +2842,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "date-fns": "^3.6.0",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.453.0",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
## Summary
- add date-fns as a runtime dependency for the frontend
- update the lockfile to capture the newly installed package

## Testing
- npm install
- npm run dev -- --host 0.0.0.0 --port 4173
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc47e520448321b79ff21fe08280a3