### PR TITLE
Ensure physical log timestamps follow event dates

### DIFF
--- a/backend/src/physical/routes.test.js
+++ b/backend/src/physical/routes.test.js
@@ -763,4 +763,32 @@ describe("physical routes GET /logs", () => {
     expect(row.source).toBe("physical");
     expect(row.pokemons).toEqual(expect.arrayContaining(["blastoise", "weezing"]));
   });
+
+  it("aligns row timestamps and dates with the stored event date", async () => {
+    const eventDate = "2024-06-01";
+    const createdAt = Date.UTC(2024, 5, 2, 12, 30);
+    eventsStore = {
+      evt4: {
+        eventId: "evt4",
+        createdAt,
+        date: eventDate,
+        deckName: "Mew Control",
+        opponent: "Misty",
+        opponentsList: ["misty"],
+        result: "W",
+      },
+    };
+
+    const handler = getLogsHandler();
+    const res = createRes();
+
+    await handler({ query: { limit: "5" } }, res);
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.rows).toHaveLength(1);
+    const [row] = res.body.rows;
+    expect(row.date).toBe(eventDate);
+    expect(row.ts).toBe(Date.parse(eventDate));
+    expect(row.createdAt).toBe(createdAt);
+  });
 });


### PR DESCRIPTION
## Summary
- prefer the event date (and dateISO) before createdAt when deriving timestamps for physical events
- propagate normalized date information when building /api/physical/logs rows
- cover the new behaviour with a regression test that checks the returned ts/date values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc662994708321ba2546d721c1601c