### PR TITLE
Handle timezone detection without process env

### DIFF
--- a/frontend/src/utils/tz.js
+++ b/frontend/src/utils/tz.js
@@ -1,4 +1,13 @@
-const TZ = process.env.TZ || "America/Sao_Paulo";
+const processTz =
+  typeof process !== "undefined" ? process?.env?.TZ : undefined;
+const viteTz =
+  typeof import.meta !== "undefined" ? import.meta?.env?.VITE_TZ : undefined;
+const browserTz =
+  typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function"
+    ? Intl.DateTimeFormat().resolvedOptions().timeZone
+    : undefined;
+
+const TZ = processTz || viteTz || browserTz || "America/Sao_Paulo";
 
 const dateFormatCache = new Map();
 function getDateFormatter(timeZone = TZ) {


### PR DESCRIPTION
## Summary
- add safe detection for timezone using process.env, Vite env, or browser fallback
- keep exported TZ constant for date helpers

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68cc6dba33348321a2d25c3631732fef