### PR TITLE
Relax filtering for physical store event matches

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -703,9 +703,7 @@ const buildEventMatches = (event = {}, roundsEntry) => {
     ? normalized.map((round, index) => buildMatchEntryFromRound(round, index))
     : normalized.map((match, index) => buildMatchEntryFromLog(match, index));
 
-  return mapped
-    .filter((entry) => entry && (entry.opponent || entry.playerDeck.label || entry.opponentDeck.label))
-    .sort((a, b) => a.order - b.order);
+  return mapped.filter(Boolean).sort((a, b) => a.order - b.order);
 };
 
 export default function PhysicalStoreEventsPage() {


### PR DESCRIPTION
## Summary
- keep physical store event match entries even when opponent or deck labels are missing so bye rounds remain visible

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc94f401908321aac534e39e32be25