### PR TITLE
Adjust match result display priority

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -1138,9 +1138,12 @@ export default function PhysicalStoreEventsPage() {
                         };
 
                         const counts = match.counts;
-                        const displayResult = counts
+                        const normalizedResult = normalizeResultToken(match.result);
+                        const displayResult = normalizedResult
+                          ? normalizedResult
+                          : counts
                           ? `${Number(counts.W || 0)}/${Number(counts.L || 0)}/${Number(counts.T || 0)}`
-                          : match.result || "—";
+                          : "—";
 
                         return (
                           <button
@@ -1165,7 +1168,12 @@ export default function PhysicalStoreEventsPage() {
                                 pokemonHints={match.userPokemons}
                               />
                             </div>
-                            <div className={`text-right font-semibold ${renderResultTone(match.result, counts)}`}>
+                            <div
+                              className={`text-right font-semibold ${renderResultTone(
+                                normalizedResult,
+                                counts,
+                              )}`}
+                            >
                               {displayResult}
                             </div>
                           </button>


### PR DESCRIPTION
## Summary
- prioritize individual round results when rendering match rows in the physical store events page
- continue to fall back to aggregated counts when a round result token is unavailable
- ensure the tone helper receives the normalized result token used for display

## Testing
- npm run lint *(fails: existing lint issues related to undefined globals such as `console`, `process`, and `fetch` in unrelated files)*
- Manual verification: started `npm run dev -- --host 0.0.0.0 --port 4173` and opened `#/tcg-fisico/eventos/loja` (blocked by backend API returning 500, screenshot attached)

------
https://chatgpt.com/codex/tasks/task_e_68cc997d5f9883218b34b1c0806acf99