### PR TITLE
Fix sampleRow assignment typo in physical store events

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -438,7 +438,7 @@ const buildGroupedStoreEvents = (events = [], roundsCache = new Map()) => {
 
     const rows = Array.isArray(entry?.rows) ? entry.rows : [];
     const detail = entry?.detail || {};
-    the const sampleRow = rows[0] || {};
+    const sampleRow = rows[0] || {};
 
     const roundsEntry = roundsCache instanceof Map ? roundsCache.get(eventId) : null;
     const cachedRounds = roundsEntry && Array.isArray(roundsEntry.rounds) ? roundsEntry.rounds : null;


### PR DESCRIPTION
## Summary
- remove the extra word in buildGroupedStoreEvents so sampleRow is assigned correctly

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cca4ff84e8832189bfc5747beccf4a