### PR TITLE
Improve aggregate Pokémon hint fallback

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -824,9 +824,24 @@ const buildMatchEntryFromAggregate = (entry, index, context = {}) => {
     nameCandidates: deckNameCandidates,
   });
 
-  const opponentPokemons = ensurePokemonHints(
-    entry?.topPokemons || preferredDeck?.pokemons,
-  );
+  let opponentPokemons = ensurePokemonHints(entry?.topPokemons);
+  if (!opponentPokemons.length) {
+    const deckCandidates = [];
+    if (preferredDeck) deckCandidates.push(preferredDeck);
+    for (const deck of decks) {
+      if (!deck) continue;
+      if (preferredDeck && deck === preferredDeck) continue;
+      deckCandidates.push(deck);
+    }
+
+    for (const deck of deckCandidates) {
+      const hints = ensurePokemonHints(deck?.pokemons);
+      if (hints.length) {
+        opponentPokemons = hints;
+        break;
+      }
+    }
+  }
 
   const totalRounds = Number.isFinite(detail?.roundsCount)
     ? Math.max(0, detail.roundsCount)

--- a/frontend/src/pages/PhysicalStoreEventsPage.test.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.test.jsx
@@ -57,4 +57,43 @@ describe("buildEventMatches", () => {
       expect(match.userPokemons).toEqual(["Comfey", "Sableye"]);
     });
   });
+
+  it("uses deck pokemons when aggregate top hints are empty", () => {
+    const event = {
+      id: "evt-hints",
+      rows: [
+        {
+          playerDeckKey: "lost-zone",
+          playerDeckName: "Lost Zone",
+          userPokemons: ["Comfey", "Sableye"],
+        },
+      ],
+      detail: {
+        roundsCount: 1,
+        opponentsList: ["Dexter"],
+        opponentsAgg: [
+          {
+            opponentName: "Dexter",
+            counts: { W: 1, L: 0, T: 0 },
+            topDeckKey: "preferred",
+            topDeckName: "Preferred Deck",
+            topPokemons: [],
+            decks: [
+              { deckKey: "preferred", deckName: "Preferred Deck", pokemons: [] },
+              {
+                deckKey: "backup",
+                deckName: "Backup Deck",
+                pokemons: ["Miraidon EX", { name: "Raikou V " }],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const matches = buildEventMatches(event, { rounds: [] });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].opponentPokemons).toEqual(["Miraidon EX", "Raikou V"]);
+  });
 });


### PR DESCRIPTION
## Summary
- prefer recorded Pokémon hints from aggregate entries when building match rows
- fall back to deck-level Pokémon lists when aggregates do not include top hints
- cover the deck-level fallback path with a new unit test

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ccad741e7c8321b6dc21fb117a1bf8