### PR TITLE
Handle primitive detail pokemons in PhysicalStoreEventsPage

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -951,7 +951,11 @@ const buildMatchesFromAggregates = (event = {}) => {
 
       if (Array.isArray(detailPokemons)) {
         for (const entry of detailPokemons) {
-          if (!entry || typeof entry !== "object") continue;
+          if (!entry) continue;
+          if (typeof entry !== "object") {
+            appendPokemonCandidates(entry);
+            continue;
+          }
           const sides = [
             normalizeSide(entry.side),
             normalizeSide(entry.label),

--- a/frontend/src/pages/PhysicalStoreEventsPage.test.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.test.jsx
@@ -137,4 +137,35 @@ describe("buildEventMatches", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0].userPokemons).toEqual(["Miraidon EX", "Raikou V"]);
   });
+
+  it("uses string-only detail pokemons for player hints", () => {
+    const event = {
+      id: "evt-string-detail-pokemons",
+      rows: [
+        {
+          playerDeckKey: "lost-zone",
+          playerDeckName: "Lost Zone",
+        },
+      ],
+      detail: {
+        roundsCount: 1,
+        opponentsList: ["Dexter"],
+        pokemons: ["Miraidon EX", "  Raikou V  ", "Miraidon EX"],
+        opponentsAgg: [
+          {
+            opponentName: "Dexter",
+            counts: { W: 1, L: 0, T: 0 },
+            decks: [
+              { deckKey: "preferred", deckName: "Preferred Deck", pokemons: [] },
+            ],
+          },
+        ],
+      },
+    };
+
+    const matches = buildEventMatches(event, { rounds: [] });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].userPokemons).toEqual(["Miraidon EX", "Raikou V"]);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure primitive entries in detail.pokemons arrays are captured when collecting player Pokémon hints
- add coverage for string-only detail.pokemons arrays to confirm the icons list is populated

## Testing
- npm test -- --run src/pages/PhysicalStoreEventsPage.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68ccb4de4288832183f39d1b73db1355