### PR TITLE
Allow store events route to accept store segment

### DIFF
--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -34,7 +34,7 @@ const routes = [
         path: "eventos",
         children: [
           { index: true, element: <EventPhysicalSummaryPage /> },
-          { path: "loja", element: <PhysicalStoreEventsPage /> },
+          { path: "loja/*", element: <PhysicalStoreEventsPage /> },
           { path: "data", element: <PhysicalDateEventsPage /> },
           { path: ":eventId", element: <EventPhysicalSummaryPage /> },
         ],


### PR DESCRIPTION
## Summary
- update the physical events routes so the store page keeps rendering when an extra path segment is present

## Testing
- Manual testing in Vite dev server: clicked the "Dragon Den TCG" entry under Liga Local and "CardHouse SP" under Cup/Challenge to confirm both deep-link to the filtered eventos/loja page

------
https://chatgpt.com/codex/tasks/task_e_68ccb80d7e348321a769c58d94a61e9b