### PR TITLE
docs: detalha rotas e navegação da loja física

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,7 +34,12 @@ npm run preview
 As telas do TCG Físico vivem sob `#/tcg-fisico`:
 
 - `#/tcg-fisico` – visão geral
+- `#/tcg-fisico/eventos/loja` – listagem agregada por loja (aceita `#/tcg-fisico/eventos/loja/:loja` para pré-selecionar a loja)
 - `#/tcg-fisico/eventos/:id` – resumo e rounds de um evento
+
+A visão por loja escreve o filtro atual na hash (`StoreEventsPage.jsx`) e observa `hashchange` para manter a loja pré-selecionada ao seguir links profundos ou usar Voltar/Avançar (`PhysicalStoreEventsPage.jsx`), preservando os filtros ativos ao navegar.
+
+Quando um evento é aberto a partir da lista da loja, o resumo recebe `?store=` na hash (`StoreEventsPage.jsx`). `EventPhysicalSummaryPage.jsx` aproveita esse parâmetro para renderizar a navegação de retorno à loja, mantendo o usuário no contexto correto ao voltar.
 
 Navegação programática para a página de evento:
 


### PR DESCRIPTION
## Summary
- documenta a rota agregada de eventos por loja e o segmento opcional para pré-seleção
- explica como a página sincroniza o filtro da loja via hashchange e mantém o contexto ao navegar
- referencia o link gerado pelo resumo de eventos para retornar ao filtro de loja

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccbd9b5d008321a6c1c892d7690915