### PR TITLE
Add physical day listing and frontend integration

### DIFF
--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -35,7 +35,7 @@ const routes = [
         children: [
           { index: true, element: <EventPhysicalSummaryPage /> },
           { path: "loja/*", element: <PhysicalStoreEventsPage /> },
-          { path: "data", element: <PhysicalDateEventsPage /> },
+          { path: "data/:dateParam?", element: <PhysicalDateEventsPage /> },
           { path: ":eventId", element: <EventPhysicalSummaryPage /> },
         ],
       },

--- a/frontend/src/services/physicalApi.js
+++ b/frontend/src/services/physicalApi.js
@@ -1,5 +1,32 @@
 import { api } from "./api.js";
 
+export const listPhysicalDays = async () => {
+  try {
+    const payload = await api(`/api/physical/days`);
+    if (Array.isArray(payload)) return { data: payload, error: null };
+    if (payload && Array.isArray(payload.dates)) {
+      return { data: payload.dates, error: null };
+    }
+    return { data: [], error: null };
+  } catch (error) {
+    return { data: [], error };
+  }
+};
+
+export const getPhysicalDay = async (date) => {
+  const key = typeof date === "string" ? date.trim() : "";
+  if (!key) {
+    const error = new Error("invalid_date");
+    return { data: null, error };
+  }
+  try {
+    const data = await api(`/api/physical/days/${encodeURIComponent(key)}`);
+    return { data, error: null };
+  } catch (error) {
+    return { data: null, error };
+  }
+};
+
 export const postPhysicalEvent = (payload) =>
   api(`/api/physical/events`, { method: "POST", body: JSON.stringify(payload) });
 


### PR DESCRIPTION
## Summary
- add an index route that lists physical day keys, enrich the day detail payload with location/type metadata and match totals, and align timestamp parsing for ISO strings
- expose `listPhysicalDays`/`getPhysicalDay` helpers and rewrite the physical day events page to load real data, drive navigation by the route parameter, and render clickable rows
- allow the physical events route to accept an optional date parameter so the dropdown updates the hash-friendly URL

## Testing
- npm test
- npm run lint *(fails: existing lint configuration flags numerous legacy files for missing globals/import order)*

------
https://chatgpt.com/codex/tasks/task_e_68cd602ef7ec832192a33ec30e9ef312