### PR TITLE
feat: switch physical tournaments page to backend data

### DIFF
--- a/frontend/src/pages/PhysicalTournamentsMock.jsx
+++ b/frontend/src/pages/PhysicalTournamentsMock.jsx
@@ -1,143 +1,182 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { listLiveTournaments, suggestLiveTournaments, getLiveTournament } from "../services/api.js";
+import {
+  listPhysicalTournaments,
+  suggestPhysicalTournaments,
+  getPhysicalTournament,
+} from "../services/physicalApi.js";
 import { prettyDeckKey } from "../services/prettyDeckKey.js";
 import DeckLabel from "../components/DeckLabel.jsx";
 
 const API = import.meta.env.VITE_API_BASE_URL || "";
+const BASE_HASH = "#/tcg-fisico/torneios";
 
 // ===== Helpers =====
-const WR  = (w=0,l=0,t=0) => { const tot=(w||0)+(l||0)+(t||0); return tot ? Math.round((w/tot)*100) : 0; };
-const PTS = (w=0,_l=0,t=0) => 3*(w||0)+(t||0);
-const fmtDate = (iso) => iso ? new Date(String(iso)+"T12:00:00").toLocaleDateString("pt-BR", { timeZone: "America/Sao_Paulo" }) : "—";
+const WR = (w = 0, l = 0, t = 0) => {
+  const tot = (w || 0) + (l || 0) + (t || 0);
+  return tot ? Math.round(((w || 0) / tot) * 100) : 0;
+};
+const PTS = (w = 0, _l = 0, t = 0) => 3 * (w || 0) + (t || 0);
+const fmtDate = (iso) =>
+  iso
+    ? new Date(String(iso) + "T12:00:00").toLocaleDateString("pt-BR", {
+        timeZone: "America/Sao_Paulo",
+      })
+    : "—";
 
-async function tryJson(url){
+async function tryJson(url) {
   try {
     const r = await fetch(url);
     if (!r.ok) return null;
     const ct = r.headers.get("content-type") || "";
     if (!ct.includes("application/json")) return null;
     return await r.json();
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
-function safeArray(p){
+
+function safeArray(p) {
   if (Array.isArray(p)) return p;
+  if (Array.isArray(p?.tournaments)) return p.tournaments;
+  if (Array.isArray(p?.suggestions)) return p.suggestions;
   if (Array.isArray(p?.rows)) return p.rows;
   if (Array.isArray(p?.data)) return p.data;
   if (Array.isArray(p?.items)) return p.items;
   if (Array.isArray(p?.result)) return p.result;
-  for (const v of Object.values(p||{})) {
-    if (Array.isArray(v) && v.length && typeof v[0]==="object") return v;
+  for (const v of Object.values(p || {})) {
+    if (Array.isArray(v) && v.length && typeof v[0] === "object") return v;
   }
   return [];
 }
 
-// === Deriva torneios apenas quando houver id de torneio OU nome (inclui `event`)
-function deriveTournamentsFromLogs(logsJson, query=""){
-  const rows = safeArray(logsJson?.rows || logsJson).filter(r => (r.source || r.origin || "live").toLowerCase().includes("live"));
-  const map = new Map();
-  for (const r of rows){
-    const tId   = r.tournamentId || r.tId || r.tournament_id || null; // nunca usar r.id (id do log)
-    const tName = r.tournamentName || r.tournament || r.tournament_name || r.tourneyName || r.event || null;
-    if (!tId && !tName) continue;
+const normalizeCounts = (payload) => {
+  const source = payload || {};
+  const toNumber = (value) => {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const W = toNumber(source.W ?? source.w ?? source.wins ?? source.win ?? source.V ?? source.v ?? 0);
+  const L = toNumber(source.L ?? source.l ?? source.losses ?? source.loss ?? source.D ?? source.d ?? 0);
+  const T = toNumber(source.T ?? source.t ?? source.ties ?? source.tie ?? source.E ?? source.e ?? source.draws ?? 0);
+  return { W, L, T };
+};
 
-    const key = tId || `name:${tName}`;
-    const dateISO = String(r.date || r.createdAt || "").slice(0,10);
-    const entry = map.get(key) || {
-      id: tId || "",               // pode ficar vazio (vamos usar key virtual no UI)
-      tournamentId: tId || "",
-      name: tName || "-",
-      dateISO,
-      format: r.format || r.gameType || r.ruleset || "-",
-      deckKey: r.deck || r.playerDeck || r.myDeck || "-",
-      counts: { W:0, L:0, T:0 },
-    };
-    const v = String(r.result || r.r || "").toUpperCase();
-    if (v==="W") entry.counts.W++; else if (v==="L") entry.counts.L++; else entry.counts.T++;
-    if (dateISO && (!entry.dateISO || entry.dateISO < dateISO)) entry.dateISO = dateISO;
-    map.set(key, entry);
-  }
-  let arr = Array.from(map.values()).map(t=>{
-    const tot = (t.counts.W||0)+(t.counts.L||0)+(t.counts.T||0);
-    return { ...t, wr: tot ? Math.round((t.counts.W/tot)*100) : 0 };
-  });
-  if (query){
-    const q=query.toLowerCase();
-    arr = arr.filter(t => String(t.name).toLowerCase().includes(q) || String(t.id).includes(q));
-  }
-  arr.sort((a,b)=> String(b.dateISO||"").localeCompare(String(a.dateISO||"")));
-  return arr;
-}
+const computeWr = (counts) => {
+  const { W = 0, L = 0, T = 0 } = counts || {};
+  const total = W + L + T;
+  return total > 0 ? Math.round((W / total) * 100) : 0;
+};
 
-async function listLiveTournamentsLocal(query=""){
+const normalizeTournament = (entry) => {
+  if (!entry || typeof entry !== "object") return null;
+  const counts = normalizeCounts(entry.counts);
+  const rawDate = entry.dateISO || entry.date || entry.day || "";
+  const dateISO = rawDate ? String(rawDate).slice(0, 10) : "";
+  const name = entry.name || entry.title || entry.tournament || entry.event || "";
+  const format = entry.format || entry.eventType || entry.type || entry.category || "";
+  const deck = entry.deck || entry.deckName || entry.playerDeck || entry.playerDeckName || entry.deckKey || entry.deckSlug || "";
+  const pokemonHints = entry.pokemonHints || entry.pokemons || entry.pokemon || entry.deckPokemons || null;
+  const idCandidates = [
+    entry.tournamentId,
+    entry.id,
+    entry.eventId,
+    entry.slug,
+    entry.limitlessId,
+    entry.identifier,
+  ]
+    .map((value) => (value == null ? "" : String(value).trim()))
+    .filter(Boolean);
+  const fallbackKey = [dateISO, name].filter(Boolean).join("|");
+  const key = idCandidates[0] || fallbackKey;
+  if (!key) return null;
+  return {
+    id: key,
+    tournamentId: idCandidates[0] || "",
+    dateISO,
+    name: name || "—",
+    format: format || "—",
+    deck,
+    pokemonHints,
+    counts,
+    wr: computeWr(counts),
+  };
+};
+
+const deriveResultFromCounts = (counts = {}) => {
+  const { W = 0, L = 0, T = 0 } = counts || {};
+  if (W > 0 && L === 0 && T === 0) return "W";
+  if (L > 0 && W === 0 && T === 0) return "L";
+  if (T > 0 && W === 0 && L === 0) return "T";
+  return "";
+};
+
+const normalizeRound = (round, index = 0) => {
+  if (!round || typeof round !== "object") return null;
+  const counts = normalizeCounts(round.counts);
+  const opponent = round.opponent || round.opponentName || round.enemy || round.opp || "";
+  const opponentDeck = round.opponentDeck || round.opponentDeckName || round.oppDeck || round.deckOpponent || "";
+  const rawResult =
+    (typeof round.result === "string" ? round.result : "") ||
+    (typeof round.outcome === "string" ? round.outcome : "") ||
+    (typeof round.finalResult === "string" ? round.finalResult : "");
+  const normalizedResult = (rawResult ? rawResult.trim().toUpperCase() : "") || deriveResultFromCounts(counts) || "-";
+  const roundNumber = round.round ?? round.roundNumber ?? round.number ?? round.roundIndex ?? null;
+  const id =
+    round.id ||
+    round.logId ||
+    round.matchId ||
+    round.eventMatchId ||
+    (round.eventId ? `${round.eventId}-${roundNumber ?? index + 1}` : "") ||
+    `round-${index}`;
+  return {
+    id,
+    round: roundNumber ?? index + 1,
+    opponent: opponent || "—",
+    opponentDeck: opponentDeck || "",
+    opponentPokemons: round.opponentPokemons || round.oppPokemons,
+    eventId: round.eventId || round.matchId || round.logId || "",
+    result: normalizedResult,
+  };
+};
+
+const fetchPhysicalTournaments = async (query = "") => {
+  const normalizedQuery = typeof query === "string" ? query.trim() : "";
+  const mapEntries = (payload) => safeArray(payload).map(normalizeTournament).filter(Boolean);
   try {
-    const r = await listLiveTournaments(query);
-    if (Array.isArray(r) && r.length) return r;
+    const payload = await listPhysicalTournaments(normalizedQuery);
+    const arr = mapEntries(payload);
+    if (arr.length) return arr;
   } catch {}
-  const e1 = await tryJson(`${API}/api/live/tournaments${query?`?query=${encodeURIComponent(query)}`:""}`);
-  if (Array.isArray(e1) && e1.length) return e1;
-  const e2 = await tryJson(`${API}/api/tournaments${query?`?query=${encodeURIComponent(query)}`:""}`);
-  if (Array.isArray(e2) && e2.length) return e2;
-  const logs = await tryJson(`${API}/api/live/logs?limit=1000`);
-  return deriveTournamentsFromLogs(logs || {}, query);
-}
+  const suffix = normalizedQuery ? `?query=${encodeURIComponent(normalizedQuery)}` : "";
+  const fallback = await tryJson(`${API}/api/physical/tournaments${suffix}`);
+  return mapEntries(fallback);
+};
 
-// === NOVO: aceita id real OU id virtual "name:<nome>"
-async function getLiveTournamentLocal(idOrKey){
-  // Se for um id virtual baseado em nome
-  if (typeof idOrKey === "string" && idOrKey.startsWith("name:")){
-    const name = idOrKey.slice(5).toLowerCase();
-    const logs = await tryJson(`${API}/api/live/logs?limit=2000`);
-    const rows = safeArray(logs?.rows || logs).filter(r => {
-      const nm = (r.tournamentName || r.tournament || r.tournament_name || r.tourneyName || r.event || "").toLowerCase();
-      return nm && nm === name;
-    });
-    const rounds = rows.map((r,idx)=>({
-      id: r.id || `${idOrKey}|${idx+1}`,
-      round: r.round || r.rnd || (idx+1),
-      deck: r.myDeck || r.deck || "-",
-      opponent: r.opponent || r.opp || "-",
-      opponentDeck: r.opponentDeck || r.oppDeck || r.opponent_deck || "-",
-      result: String(r.result || r.r || "-").toUpperCase(),
-      gameOrder: r.gameOrder || r.order || "-",
-    }));
-    const dateISO = String(rows[0]?.date || rows[0]?.createdAt || "").slice(0,10);
-    const counts = rounds.reduce((a,r)=>{ if(r.result==="W") a.W++; else if(r.result==="L") a.L++; else a.T++; return a; }, {W:0,L:0,T:0});
-    return { id: idOrKey, name: idOrKey.slice(5), dateISO, counts, rounds };
-  }
-
-  // Fluxo com ID real de torneio
+const fetchPhysicalTournamentRounds = async (id) => {
+  const key = typeof id === "string" ? id.trim() : "";
+  if (!key) return [];
+  const mapRounds = (payload) => safeArray(payload).map((round, index) => normalizeRound(round, index)).filter(Boolean);
   try {
-    const r = await getLiveTournament(idOrKey);
-    if (r && (Array.isArray(r.rounds) || r.id)) return r;
+    const payload = await getPhysicalTournament(key);
+    const rounds = mapRounds(payload?.rounds ?? payload);
+    if (rounds.length) return rounds;
+    const tournamentRounds = mapRounds(payload?.tournament);
+    if (tournamentRounds.length) return tournamentRounds;
   } catch {}
-  const e1 = await tryJson(`${API}/api/live/tournaments/${idOrKey}`);
-  if (e1 && (Array.isArray(e1.rounds) || e1.id)) return e1;
+  const fallback = await tryJson(`${API}/api/physical/tournaments/${encodeURIComponent(key)}`);
+  return mapRounds(fallback?.rounds ?? fallback?.tournament ?? fallback);
+};
 
-  // Fallback por ID real dentro dos logs
-  const logs = await tryJson(`${API}/api/live/logs?limit=2000`);
-  const rows = safeArray(logs?.rows || logs).filter(r => (r.tournamentId || r.tId || r.tournament_id) == idOrKey);
-  const rounds = rows.map((r,idx)=>({
-    id: r.id || `${idOrKey}|${idx+1}`,
-    round: r.round || r.rnd || (idx+1),
-    deck: r.myDeck || r.deck || "-",
-    opponent: r.opponent || r.opp || "-",
-    opponentDeck: r.opponentDeck || r.oppDeck || r.opponent_deck || "-",
-    result: String(r.result || r.r || "-").toUpperCase(),
-    gameOrder: r.gameOrder || r.order || "-",
-  }));
-  const name = rows[0]?.tournamentName || rows[0]?.tournament || rows[0]?.event || `Torneio #${String(idOrKey).slice(-6)}`;
-  const dateISO = String(rows[0]?.date || rows[0]?.createdAt || "").slice(0,10);
-  const counts = rounds.reduce((a,r)=>{ if(r.result==="W") a.W++; else if(r.result==="L") a.L++; else a.T++; return a; }, {W:0,L:0,T:0});
-  return { id: idOrKey, name, dateISO, counts, rounds };
-}
-
-function getQueryFromHash(){
+function getQueryFromHash() {
   try {
     const h = window.location.hash || "";
+    if (!h.startsWith(BASE_HASH)) return "";
     const q = h.includes("?") ? h.split("?")[1] : "";
     const usp = new URLSearchParams(q);
     return usp.get("query") || "";
-  } catch { return ""; }
+  } catch {
+    return "";
+  }
 }
 
 // ===== Página principal =====
@@ -155,71 +194,125 @@ export default function TournamentsLivePage() {
   const [openId, setOpenId] = useState(null);
   const [openRounds, setOpenRounds] = useState({});
 
-  useEffect(()=>{
+  const runSearch = async (query = "") => {
+    try {
+      setLoading(true);
+      const data = await fetchPhysicalTournaments(query);
+      setRows(Array.isArray(data) ? data : []);
+    } catch {
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const buildSuggestionList = (entries = []) =>
+    (Array.isArray(entries) ? entries : [])
+      .slice(0, 10)
+      .map((t, index) => ({
+        key: t.tournamentId || t.id || `${t.name || "torneio"}-${index}`,
+        id: t.tournamentId || t.id || "",
+        name: t.name || "—",
+        dateISO: t.dateISO || "",
+      }));
+
+  useEffect(() => {
+    let cancelled = false;
     const apply = async (query) => {
-      try { setLoading(true); const data = await listLiveTournamentsLocal(query||""); setRows(Array.isArray(data)?data:[]); }
-      finally { setLoading(false); }
+      try {
+        setLoading(true);
+        const data = await fetchPhysicalTournaments(query);
+        if (!cancelled) setRows(Array.isArray(data) ? data : []);
+      } catch {
+        if (!cancelled) setRows([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     };
     const initial = getQueryFromHash();
-    if (initial){ setQ(initial); apply(initial); } else { apply(""); }
-    const onHash = ()=>{ const q2 = getQueryFromHash(); setQ(q2); apply(q2); };
+    if (initial) {
+      setQ(initial);
+      apply(initial);
+    } else {
+      apply("");
+    }
+    const onHash = () => {
+      const q2 = getQueryFromHash();
+      setQ(q2);
+      apply(q2);
+    };
     window.addEventListener("hashchange", onHash);
-    return ()=>window.removeEventListener("hashchange", onHash);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("hashchange", onHash);
+    };
   }, []);
 
-  async function onChangeQuery(e){
+  async function onChangeQuery(e) {
     const v = e.target.value;
     setQ(v);
-    setSuggestionsOpen(!!v && v.length>=2);
-    if (v && v.length>=2){
+    const trimmed = v.trim();
+    const shouldOpen = trimmed.length >= 2;
+    setSuggestionsOpen(shouldOpen);
+    if (shouldOpen) {
       try {
-        const s = await suggestLiveTournaments(v);
-        setSuggestions(Array.isArray(s)&&s.length ? s : (await listLiveTournamentsLocal(v)).slice(0,10).map(t=>({id:t.id||t.tournamentId,name:t.name,dateISO:t.dateISO})));
+        const payload = await suggestPhysicalTournaments(trimmed);
+        const normalized = safeArray(payload).map(normalizeTournament).filter(Boolean);
+        const list = normalized.length ? normalized : await fetchPhysicalTournaments(trimmed);
+        setSuggestions(buildSuggestionList(list));
       } catch {
-        const s2 = (await listLiveTournamentsLocal(v)).slice(0,10).map(t=>({id:t.id||t.tournamentId,name:t.name,dateISO:t.dateISO}));
-        setSuggestions(s2);
+        const fallbackList = await fetchPhysicalTournaments(trimmed);
+        setSuggestions(buildSuggestionList(fallbackList));
       }
     } else {
       setSuggestions([]);
     }
-    try { setRows(await listLiveTournamentsLocal(v)); } catch {}
-  }
-  async function selectSuggestion(s){
-    const v = s?.name || s?.id || "";
-    setQ(v); setSuggestionsOpen(false); setSuggestions([]);
-    try { setRows(await listLiveTournamentsLocal(v)); } catch {}
-    try { const base="#/tcg-live/torneios"; window.location.hash = v ? `${base}?query=${encodeURIComponent(v)}` : base; } catch {}
+    await runSearch(v);
   }
 
-  const filtered = useMemo(()=>{
+  async function selectSuggestion(s) {
+    const v = s?.name || s?.id || "";
+    setQ(v);
+    setSuggestionsOpen(false);
+    setSuggestions([]);
+    await runSearch(v);
+    try {
+      window.location.hash = v ? `${BASE_HASH}?query=${encodeURIComponent(v)}` : BASE_HASH;
+    } catch {}
+  }
+
+  const filtered = useMemo(() => {
     let arr = [...rows];
-    if (status!=="todos") { arr = arr.filter(()=>true); }
-    if (format!=="todos") { arr = arr.filter(()=>true); }
-    arr.sort((a,b)=> String(b.dateISO||b.date||"").localeCompare(String(a.dateISO||a.date||"")));
+    if (status !== "todos") { arr = arr.filter(() => true); }
+    if (format !== "todos") { arr = arr.filter(() => true); }
+    arr.sort((a,b)=> String(b.dateISO || b.date || "").localeCompare(String(a.dateISO || a.date || "")));
     return arr;
   }, [rows, status, format]);
 
-  const aggregates = useMemo(()=>{
-    const a = filtered.reduce((acc,t)=>{
-      const c = t.counts || { W:t.wins||0, L:t.losses||0, T:t.ties||0 };
+  const aggregates = useMemo(() => {
+    const a = filtered.reduce((acc, t) => {
+      const c = normalizeCounts(t.counts);
       acc.count += 1;
-      acc.w += c.W||0; acc.l += c.L||0; acc.t += c.T||0;
-      acc.matches += (c.W||0)+(c.L||0)+(c.T||0);
+      acc.w += c.W || 0;
+      acc.l += c.L || 0;
+      acc.t += c.T || 0;
+      acc.matches += (c.W || 0) + (c.L || 0) + (c.T || 0);
       return acc;
-    }, {count:0, matches:0, w:0, l:0, t:0});
-    return { ...a, wr: WR(a.w,a.l,a.t), pts: PTS(a.w,a.l,a.t) };
+    }, { count: 0, matches: 0, w: 0, l: 0, t: 0 });
+    return { ...a, wr: WR(a.w, a.l, a.t), pts: PTS(a.w, a.l, a.t) };
   }, [filtered]);
 
-  // Agora aceita id real ou virtual "name:<nome>"
-  async function toggleOpen(idOrKey){
-    if (openId === idOrKey){ setOpenId(null); return; }
-    setOpenId(idOrKey);
-    if (!openRounds[idOrKey]){
+  async function toggleOpen(id) {
+    const key = typeof id === "string" ? id : "";
+    if (!key) return;
+    if (openId === key) { setOpenId(null); return; }
+    setOpenId(key);
+    if (!openRounds[key]) {
       try {
-        const d = await getLiveTournamentLocal(idOrKey);
-        setOpenRounds(prev => ({...prev, [idOrKey]: Array.isArray(d?.rounds) ? d.rounds : [] }));
+        const rounds = await fetchPhysicalTournamentRounds(key);
+        setOpenRounds((prev) => ({ ...prev, [key]: Array.isArray(rounds) ? rounds : [] }));
       } catch {
-        setOpenRounds(prev => ({...prev, [idOrKey]: [] }));
+        setOpenRounds((prev) => ({ ...prev, [key]: [] }));
       }
     }
   }
@@ -229,10 +322,10 @@ export default function TournamentsLivePage() {
       <div className="mx-auto max-w-7xl px-4 py-6">
         <header className="mb-6">
           <h1 className="text-2xl font-semibold tracking-tight">
-            <a href="#/tcg-live/torneios" className="hover:underline">Torneios — TCG Live</a>
+            <a href={BASE_HASH} className="hover:underline">Torneios — TCG Físico</a>
           </h1>
           <p className="mt-1 text-sm text-zinc-400">
-            Importe logs para criar novos torneios. Informe o Limitless ID, ou marque que não possui para inserir manualmente o nome.
+            Acompanhe o desempenho em torneios presenciais registrados. Busque pelo nome ou identificador para filtrar rapidamente os resultados.
           </p>
         </header>
 
@@ -241,15 +334,15 @@ export default function TournamentsLivePage() {
             <input
               value={q}
               onChange={onChangeQuery}
-              placeholder="Buscar por torneio (nome) ou ID (limitless:..., manual:...)"
+              placeholder="Buscar por torneio físico (nome ou ID)"
               className="w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-emerald-600"
             />
-            {suggestionsOpen && suggestions.length>0 && (
+            {suggestionsOpen && suggestions.length > 0 && (
               <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 shadow-xl">
-                {suggestions.map(s=>(
+                {suggestions.map((s) => (
                   <button
-                    key={s.id}
-                    onClick={()=>selectSuggestion(s)}
+                    key={s.key || s.id || s.name}
+                    onClick={() => selectSuggestion(s)}
                     className="block w-full px-3 py-2 text-left text-sm hover:bg-zinc-800"
                   >
                     <div className="font-medium">{s.name}</div>
@@ -283,27 +376,27 @@ export default function TournamentsLivePage() {
             <tbody>
               {loading ? (
                 <tr><td colSpan={7} className="px-4 py-10 text-center text-zinc-400">Carregando…</td></tr>
-              ) : filtered.length===0 ? (
+              ) : filtered.length === 0 ? (
                 <tr><td colSpan={7} className="px-4 py-10 text-center text-zinc-400">Nenhum torneio encontrado.</td></tr>
-              ) : filtered.map((t,i)=>{
-                const counts = t.counts || { W:t.wins||0, L:t.losses||0, T:t.ties||0 };
-                const wr = t.wr ?? WR(counts.W,counts.L,counts.T);
-                const dateISO = t.dateISO || t.date || "";
-                const name = t.name || t.tournamentName || "—";
+              ) : filtered.map((t, i) => {
+                const counts = normalizeCounts(t.counts);
+                const wr = Number.isFinite(t.wr) ? t.wr : WR(counts.W, counts.L, counts.T);
+                const dateISO = t.dateISO || "";
+                const name = t.name || "—";
                 const format = t.format || "—";
-                const deck = prettyDeckKey(t.deckKey || t.deck || "—");
-                const realId = t.id || t.tournamentId || "";
-                const keyForToggle = realId || (name ? `name:${name}` : "");
-
-                const canOpen = !!keyForToggle;
+                const deckLabel = prettyDeckKey(t.deck || "") || "—";
+                const tournamentId = t.tournamentId || t.id || "";
+                const rowKey = tournamentId || `${name}-${dateISO}-${i}`;
+                const canOpen = Boolean(tournamentId);
+                const rounds = openRounds[tournamentId] || [];
 
                 return (
-                  <React.Fragment key={realId || name || i}>
+                  <React.Fragment key={rowKey}>
                     <tr className="border-t border-zinc-800 hover:bg-zinc-900/50">
                       <Td>{fmtDate(dateISO)}</Td>
                       <Td><span className="truncate font-medium">{name}</span></Td>
                       <Td className="hidden md:table-cell text-zinc-300">{format}</Td>
-                      <Td className="hidden md:table-cell text-zinc-300"><DeckLabel deckName={deck} pokemonHints={t.pokemons} /></Td>
+                      <Td className="hidden md:table-cell text-zinc-300"><DeckLabel deckName={deckLabel} pokemonHints={t.pokemonHints} /></Td>
                       <Td className="text-center">
                         <div className="inline-flex items-center gap-1 text-xs">
                           <span className="px-2 py-0.5 rounded-md bg-green-900/40 text-green-300 border border-green-800">W{counts.W}</span>
@@ -314,13 +407,13 @@ export default function TournamentsLivePage() {
                       <Td className="text-center">{wr}%</Td>
                       <Td className="px-4 py-3 text-right">
                         {canOpen ? (
-                          <button onClick={()=>toggleOpen(keyForToggle)} className="rounded-lg border border-zinc-700 px-3 py-1.5 hover:bg-zinc-800">
-                            {openId===keyForToggle ? "Fechar" : "Detalhes"}
+                          <button onClick={() => toggleOpen(tournamentId)} className="rounded-lg border border-zinc-700 px-3 py-1.5 hover:bg-zinc-800">
+                            {openId === tournamentId ? "Fechar" : "Detalhes"}
                           </button>
                         ) : <span className="text-zinc-600">—</span>}
                       </Td>
                     </tr>
-                    {openId===keyForToggle && (
+                    {openId === tournamentId && (
                       <tr className="bg-zinc-950/60">
                         <td colSpan={7} className="px-6 py-3">
                           <div className="text-sm text-zinc-300">Partidas</div>
@@ -335,20 +428,28 @@ export default function TournamentsLivePage() {
                                 </tr>
                               </thead>
                               <tbody>
-                                {(openRounds[keyForToggle]||[]).map(r=>(
-                                  <tr key={r.id} className="border-b border-zinc-800 hover:bg-zinc-900/60 cursor-pointer" onClick={()=>{ window.location.hash = `#/tcg-live/logs/${r.id}`; }}>
-                                    <td className="px-3 py-2">{r.round || "-"}</td>
-                                    <td className="px-3 py-2">{r.opponent || "-"}</td>
-                                    <td className="px-3 py-2"><DeckLabel deckName={prettyDeckKey(r.opponentDeck || "-")} pokemonHints={r.opponentPokemons || r.oppPokemons} /></td>
-                                    <td className="px-3 py-2 text-center">
-                                      <span className={`px-2 py-0.5 rounded-md text-xs border ${
-                                        r.result==='W' ? 'bg-emerald-500/10 text-emerald-300 border-emerald-700' :
-                                        r.result==='L' ? 'bg-rose-500/10 text-rose-300 border-rose-700' :
-                                                          'bg-amber-500/10 text-amber-300 border-amber-700'
-                                      }`}>{r.result || "-"}</span>
-                                    </td>
-                                  </tr>
-                                ))}
+                                {rounds.length === 0 ? (
+                                  <tr><td colSpan={4} className="px-3 py-3 text-center text-zinc-500">Sem partidas registradas.</td></tr>
+                                ) : rounds.map((r, idx) => {
+                                  const roundHref = r.eventId ? `#/tcg-fisico/eventos/${encodeURIComponent(r.eventId)}` : null;
+                                  const roundKey = r.id || `${tournamentId}-round-${idx}`;
+                                  const rowClass = roundHref ? "border-b border-zinc-800 hover:bg-zinc-900/60 cursor-pointer" : "border-b border-zinc-800";
+                                  const onClick = roundHref ? () => { window.location.hash = roundHref; } : undefined;
+                                  return (
+                                    <tr key={roundKey} className={rowClass} onClick={onClick}>
+                                      <td className="px-3 py-2">{r.round || "-"}</td>
+                                      <td className="px-3 py-2">{r.opponent || "-"}</td>
+                                      <td className="px-3 py-2"><DeckLabel deckName={prettyDeckKey(r.opponentDeck || "-")} pokemonHints={r.opponentPokemons || r.oppPokemons} /></td>
+                                      <td className="px-3 py-2 text-center">
+                                        <span className={`px-2 py-0.5 rounded-md text-xs border ${
+                                          r.result === 'W' ? 'bg-emerald-500/10 text-emerald-300 border-emerald-700' :
+                                          r.result === 'L' ? 'bg-rose-500/10 text-rose-300 border-rose-700' :
+                                                            'bg-amber-500/10 text-amber-300 border-amber-700'
+                                        }`}>{r.result || "-"}</span>
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
                               </tbody>
                             </table>
                           </div>
@@ -367,7 +468,6 @@ export default function TournamentsLivePage() {
     </div>
   );
 }
-
 // ===== UI helpers =====
 function Th({ children, className = "" }) { return <th className={`px-4 py-3 text-left font-medium ${className}`}>{children}</th>; }
 function Td({ children, className = "" }) { return <td className={`px-4 py-3 align-middle ${className}`}>{children}</td>; }

--- a/frontend/src/services/physicalApi.js
+++ b/frontend/src/services/physicalApi.js
@@ -66,3 +66,17 @@ export const deletePhysicalRound = async (eventId, roundId) => {
     },
   );
 };
+
+export const listPhysicalTournaments = async (query = "") => {
+  const params = new URLSearchParams();
+  if (query) params.set("query", query);
+  const search = params.toString();
+  const suffix = search ? `?${search}` : "";
+  return api(`/api/physical/tournaments${suffix}`);
+};
+
+export const suggestPhysicalTournaments = (query) =>
+  api(`/api/physical/tournaments/suggest?query=${encodeURIComponent(query || "")}`);
+
+export const getPhysicalTournament = (id) =>
+  api(`/api/physical/tournaments/${encodeURIComponent(id)}`);


### PR DESCRIPTION
## Summary
- add physical tournaments API helpers for list, suggest and detail endpoints
- rework physical tournaments page to fetch backend data with new helpers
- update UI to reflect physical hash, search suggestions and backend-backed rounds

## Testing
- npm --prefix frontend run lint *(fails: lint configuration assumes browser globals and project-specific rules outside the scope of this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7f492f1c8321bd7612138ac694c2