### PR TITLE
Add Special Event support in new event dialog

### DIFF
--- a/frontend/src/components/NovoRegistroDialog.jsx
+++ b/frontend/src/components/NovoRegistroDialog.jsx
@@ -103,6 +103,7 @@ const NovoRegistroDialog = forwardRef(function NovoRegistroDialog(
     "Liga Local",
     "Mundial",
     "Partida Amistosa",
+    "Special Event",
     "Regional",
   ].sort((a, b) => a.localeCompare(b, "pt-BR"));
 
@@ -133,7 +134,10 @@ const NovoRegistroDialog = forwardRef(function NovoRegistroDialog(
     tipo === "Challenge" ||
     tipo === "CLP";
   const exigeCidade =
-    tipo === "Regional" || tipo === "Internacional" || tipo === "Mundial";
+    tipo === "Regional" ||
+    tipo === "Internacional" ||
+    tipo === "Mundial" ||
+    tipo === "Special Event";
 
   const validate = () => {
     const e = {};


### PR DESCRIPTION
## Summary
- include the Special Event type in the new event dialog list of event types
- require a city name when registering Special Event tournaments to align with other large events

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cde3fee2c483219f57de06bb0de8f1