### PR TITLE
Add physical tournament type filtering end-to-end

### DIFF
--- a/frontend/src/services/physicalApi.js
+++ b/frontend/src/services/physicalApi.js
@@ -67,10 +67,19 @@ export const deletePhysicalRound = async (eventId, roundId) => {
   );
 };
 
-export const listPhysicalTournaments = async (query = "") => {
-  const params = new URLSearchParams();
-  if (query) params.set("query", query);
-  const search = params.toString();
+export const listPhysicalTournaments = async (params = {}) => {
+  let query = "";
+  let type = "";
+  if (typeof params === "string") {
+    query = params;
+  } else if (params && typeof params === "object") {
+    if (params.query) query = params.query;
+    if (params.type) type = params.type;
+  }
+  const usp = new URLSearchParams();
+  if (query) usp.set("query", query);
+  if (type) usp.set("type", type);
+  const search = usp.toString();
   const suffix = search ? `?${search}` : "";
   return api(`/api/physical/tournaments${suffix}`);
 };


### PR DESCRIPTION
## Summary
- normalize known tournament types on the frontend to detect type searches, sync the hash, and filter table results accordingly
- accept both query and type parameters when loading physical tournaments from the client service helper
- add backend support for normalizing the type query parameter and filtering tournaments by their format metadata before sorting

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdee2bf3b4832180064560496ba1bc