### PR TITLE
Fix syncHash callback dependencies

### DIFF
--- a/frontend/src/pages/PhysicalTournamentsMock.jsx
+++ b/frontend/src/pages/PhysicalTournamentsMock.jsx
@@ -342,7 +342,7 @@ export default function TournamentsLivePage() {
         window.location.hash = nextHash;
       }
     } catch {}
-  }, [syncHash]);
+  }, []);
 
   const runSearch = useCallback(async (searchParams = {}) => {
     try {


### PR DESCRIPTION
## Summary
- update PhysicalTournamentsMock syncHash hook to use a stable dependency array and stop self-referencing

## Testing
- VITE_API_BASE_URL=http://127.0.0.1:8787 npm run dev -- --host 0.0.0.0 --port 4173
- Manual verification of #/tcg-fisico/torneios hash updates via browser automation


------
https://chatgpt.com/codex/tasks/task_e_68cdf37e481c83218f9ef7ad3dda132f