### PR TITLE
Capture tournament event type metadata

### DIFF
--- a/backend/src/physical/tournamentTypes.js
+++ b/backend/src/physical/tournamentTypes.js
@@ -1,0 +1,54 @@
+const TOURNAMENT_TYPE_FILTER_OPTIONS = [
+  {
+    value: "regional",
+    keywords: ["regional", "regional championship", "regional championships"],
+  },
+  {
+    value: "special",
+    keywords: ["special", "special event", "special events"],
+  },
+  {
+    value: "international",
+    keywords: [
+      "international",
+      "international championship",
+      "international championships",
+      "internacional",
+      "internacional championship",
+      "internacional championships",
+    ],
+  },
+  {
+    value: "worlds",
+    keywords: [
+      "worlds",
+      "world championship",
+      "world championships",
+      "mundial",
+      "campeonato mundial",
+    ],
+  },
+];
+
+function normalizeAscii(value) {
+  if (typeof value !== "string") return "";
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+export function normalizeTournamentTypeFilter(value) {
+  const ascii = normalizeAscii(value);
+  if (!ascii) return null;
+  for (const option of TOURNAMENT_TYPE_FILTER_OPTIONS) {
+    const match = option.keywords.some(
+      (keyword) => ascii === keyword || ascii.includes(keyword),
+    );
+    if (match) return option.value;
+  }
+  return null;
+}
+
+export { TOURNAMENT_TYPE_FILTER_OPTIONS };


### PR DESCRIPTION
## Summary
- capture tournament event type metadata when recomputing physical aggregates and persist the normalized key
- share tournament type normalization helpers across the physical backend and prioritize the new fields when filtering tournaments
- update the physical tournaments mock page to consume and display the new event type fields while keeping filtering compatible

## Testing
- npm run lint *(fails: existing lint violations across unrelated frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf7a279b883219190bbd4828191ba