### PR TITLE
Prioritize event type in store events table

### DIFF
--- a/frontend/src/pages/PhysicalStoreEventsPage.jsx
+++ b/frontend/src/pages/PhysicalStoreEventsPage.jsx
@@ -1391,8 +1391,8 @@ export default function PhysicalStoreEventsPage() {
                   <div className="text-zinc-200">
                     {displayDate}
                   </div>
-                  <div className="text-zinc-300 truncate" title={ev.title || ev.eventType}>
-                    {ev.title || ev.eventType || "—"}
+                  <div className="text-zinc-300 truncate" title={ev.eventType || ev.title || "—"}>
+                    {ev.eventType || ev.title || "—"}
                   </div>
                   <div className="text-zinc-300 truncate" title={storeLabel}>
                     {storeLabel}


### PR DESCRIPTION
## Summary
- prioritize the event type value when rendering the Evento column in the physical store events table

## Testing
- npm run lint *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb6e1e414832193253ed210c24cad