### PR TITLE
Adjust top deck sorting tie-breaker

### DIFF
--- a/backend/src/home/routes.js
+++ b/backend/src/home/routes.js
@@ -166,7 +166,11 @@ async function sourceSummary(prefix, limitDays){
         pokemons,
       };
     })
-    .sort((a, b) => b.wr - a.wr)
+    .sort((a, b) => {
+      const wrDiff = b.wr - a.wr;
+      if (wrDiff !== 0) return wrDiff;
+      return total(b.counts) - total(a.counts);
+    })
     .slice(0, 5);
   // opponents
   const oppSnap = await db.collection(`${prefix}OpponentsAgg`).get();
@@ -285,7 +289,14 @@ function mergeHome(a, b, limitDays){
     if ((!Array.isArray(prev.pokemons) || prev.pokemons.length===0) && (x.pokemons||[]).length) prev.pokemons = x.pokemons;
     dm.set(x.deckKey, prev);
   }
-  const topDecks = Array.from(dm.values()).map(d => ({ deckKey:d.deckKey, counts:d.counts, wr: wrPercent(d.counts), avatars:d.avatars||[], pokemons:d.pokemons||[] })).sort((a,b)=>b.wr-a.wr).slice(0,5);
+  const topDecks = Array.from(dm.values())
+    .map(d => ({ deckKey:d.deckKey, counts:d.counts, wr: wrPercent(d.counts), avatars:d.avatars||[], pokemons:d.pokemons||[] }))
+    .sort((a,b)=>{
+      const wrDiff = b.wr - a.wr;
+      if (wrDiff !== 0) return wrDiff;
+      return total(b.counts) - total(a.counts);
+    })
+    .slice(0,5);
 
   // topOpponents (merge by opponentName)
   const om = new Map();

--- a/backend/src/home/routes.test.js
+++ b/backend/src/home/routes.test.js
@@ -189,4 +189,41 @@ describe('home routes GET /home', () => {
       wr: 0
     });
   });
+
+  it('orders decks with equal win rate by total games', async () => {
+    decksDocs.splice(
+      0,
+      decksDocs.length,
+      {
+        deckKey: 'deck-higher-total',
+        counts: { W: 6, L: 3, T: 0 },
+        wr: 66.7,
+        pokemons: ['mew']
+      },
+      {
+        deckKey: 'deck-lower-total',
+        counts: { W: 2, L: 1, T: 0 },
+        wr: 66.7,
+        pokemons: ['mewtwo']
+      }
+    );
+
+    const handler = getHomeHandler();
+    const req = { query: { source: 'physical', limit: '5' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.body.topDecks.map((d) => d.deckKey)).toEqual([
+      'deck-higher-total',
+      'deck-lower-total'
+    ]);
+
+    expect(res.body.summary.topDeck).toEqual({
+      deckKey: 'deck-higher-total',
+      wr: 66.7,
+      avatars: ['mew'],
+      pokemons: ['mew']
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- apply a deterministic tie-breaker for top deck rankings using total games when win rates match
- reuse the same tie-breaking logic when merging sources in `mergeHome`
- cover the tie-break scenario with a new home route test to ensure the highest volume deck is preferred and reflected in the summary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceba3661088321ba3b1dc734fb387a